### PR TITLE
fix off by one error

### DIFF
--- a/pywisp/gui.py
+++ b/pywisp/gui.py
@@ -690,7 +690,7 @@ class MainGui(QMainWindow):
         return list
 
     def updateData(self, data):
-        if len(data.split(';')) != len(self.dataPointBuffers):
+        if len(data.split(';')) != len(self.dataPointBuffers) + 1:
             self._logger.warning("Fehler bei der Datenübertragung")
             return
         for value in data.split(';'):


### PR DESCRIPTION
Der Mikrocontroller schickt jeweils die Zeit als erste Datenpunkte, diese werden in der `testbench.py` aber nicht als `dataPoints` angegeben. Dieser Fix erwartet einfach, dass die Zeit mit übertragen wird, auch wenn sie nicht angegeben wurde.