### PR TITLE
default to no heartbeat

### DIFF
--- a/pywisp/gui.py
+++ b/pywisp/gui.py
@@ -44,7 +44,7 @@ class MainGui(QMainWindow):
 
         # general config parameters
         self.configTimerTime = 100
-        self.configHeartbeatTime = 250
+        self.configHeartbeatTime = 0
         self.configInterpolationPoints = 100
         self.configMovingWindowEnable = False
         self.configMovingWindowSize = 10


### PR DESCRIPTION
we talked about this at some point, just ran into it myself.
this turns off the heartbeat feature by default, can be turned on by adding 
```
Config:
    Heartbeat: 250
```
to the `default.sreg` file.
note: set your requested heartbeat time in ms instead of  the 250