### PR TITLE
Fix issues with default.sreg handling

### DIFF
--- a/pywisp/gui.py
+++ b/pywisp/gui.py
@@ -1144,34 +1144,15 @@ class MainGui(QMainWindow):
     def configureRemote(self, idx):
         self.remoteWidgetLayout.clearAll()
 
-        if 'Remote' in self._experiments[idx]:
-            if self._experiments[idx] is not None:
-                for name in self._experiments[idx]['Remote']:
-                    msg = dict()
-                    msg['name'] = name
-                    msg['module'] = self._experiments[idx]['Remote'][name]['Module']
-                    msg['parameter'] = self._experiments[idx]['Remote'][name]['Parameter']
-                    msg['widgetType'] = self._experiments[idx]['Remote'][name]['widgetType']
-                    if msg['widgetType'] == "PushButton":
-                        msg['shortcut'] = self._experiments[idx]['Remote'][name]['shortcut']
-                        msg['valueOn'] = str(self._experiments[idx]['Remote'][name]['valueOn'])
-                    elif msg['widgetType'] == "Switch":
-                        msg['shortcut'] = self._experiments[idx]['Remote'][name]['shortcut']
-                        msg['valueOn'] = str(self._experiments[idx]['Remote'][name]['valueOn'])
-                        msg['valueOff'] = str(
-                            self._experiments[idx]['Remote'][name]['valueOff'])
-                    elif msg['widgetType'] == "Slider":
-                        msg['shortcutPlus'] = self._experiments[idx]['Remote'][name]['shortcutPlus']
-                        msg['shortcutMinus'] = self._experiments[idx]['Remote'][name]['shortcutMinus']
-                        msg['minSlider'] = self._experiments[idx]['Remote'][name]['minSlider']
-                        msg['maxSlider'] = self._experiments[idx]['Remote'][name]['maxSlider']
-                        msg['stepSlider'] = self._experiments[idx]['Remote'][name]['stepSlider']
-                        msg['startValue'] = self._experiments[idx][msg['module']][msg['parameter']]
-                    else:
-                        continue
-                    self.remoteAddWidget(msg)
-            else:
-                self._logger.warning("Remote not correct configured in file!")
+        if 'Remote' not in self._experiments[idx]:
+            return
+        if self._experiments[idx] is None:
+            self._logger.warning("Remote not correct configured in file!")
+            return
+        for name in self._experiments[idx]['Remote']:
+            config = self._experiments[idx]['Remote'][name]
+            config['name'] = name
+            self.remoteAddWidget(config)
 
     def configureVisualizer(self, idx):
         if self.visualizer is not None:
@@ -1480,107 +1461,83 @@ class MainGui(QMainWindow):
         idx = self.experimentList.row(self._currentExpListItem)
         exp = self.exp.getExperiment()
         del exp['Name']
-        msg, ok = RemoteWidgetEdit.getData(exp, editWidget, **(widget.getData()))
+        config, ok = RemoteWidgetEdit.getData(exp, editWidget, **(widget.getData()))
         if not ok:
             return
-        else:
-            if not 'Remote' in self._experiments[idx]:
-                self._experiments[idx]['Remote'] = {}
-            del self._experiments[idx]['Remote'][widget.widgetName]
-            self._experiments[idx]['Remote'][msg['name']] = {}
-            self._experiments[idx]['Remote'][msg['name']]['widgetType'] = msg['widgetType']
-            self._experiments[idx]['Remote'][msg['name']]['Module'] = msg['module']
-            self._experiments[idx]['Remote'][msg['name']]['Parameter'] = msg['parameter']
+        if not 'Remote' in self._experiments[idx]:
+            self._experiments[idx]['Remote'] = {}
+        del self._experiments[idx]['Remote'][widget.widgetName]
 
-            widget.widgetName = msg['name']
-            widget.widgetType = msg['widgetType']
-            widget.module = msg['module']
-            widget.parameter = msg['parameter']
-            if msg['widgetType'] == "PushButton":
-                widget.valueOn = msg['valueOn']
-                widget.shortcut.setKey(msg['shortcut'])
-                self._experiments[idx]['Remote'][msg['name']]['shortcut'] = msg['shortcut']
-                self._experiments[idx]['Remote'][msg['name']]['valueOn'] = msg['valueOn']
-            elif msg['widgetType'] == "Switch":
-                widget.valueOn = msg['valueOn']
-                widget.valueOff = msg['valueOff']
-                widget.shortcut.setKey(msg['shortcut'])
-                self._experiments[idx]['Remote'][msg['name']]['shortcut'] = msg['shortcut']
-                self._experiments[idx]['Remote'][msg['name']]['valueOn'] = msg['valueOn']
-                self._experiments[idx]['Remote'][msg['name']]['valueOff'] = msg['valueOff']
-            elif msg['widgetType'] == "Slider":
-                widget.minSlider = msg['minSlider']
-                widget.maxSlider = msg['maxSlider']
-                widget.stepSlider = msg['stepSlider']
-                widget.shortcutPlus.setKey(msg['shortcutPlus'])
-                self._experiments[idx]['Remote'][msg['name']]['shortcutPlus'] = msg['shortcutPlus']
-                widget.shortcutMinus.setKey(msg['shortcutMinus'])
-                self._experiments[idx]['Remote'][msg['name']]['shortcutMinus'] = msg['shortcutMinus']
-                self._experiments[idx]['Remote'][msg['name']]['minSlider'] = msg['minSlider']
-                self._experiments[idx]['Remote'][msg['name']]['maxSlider'] = msg['maxSlider']
-                self._experiments[idx]['Remote'][msg['name']]['stepSlider'] = msg['stepSlider']
-            widget.updateData()
+        widget.widgetName = config['name']
+        widget.widgetType = config['widgetType']
+        widget.module = config['Module']
+        widget.parameter = config['Parameter']
+        if config['widgetType'] == "PushButton":
+            widget.valueOn = config['valueOn']
+            widget.shortcut.setKey(config['shortcut'])
+        elif config['widgetType'] == "Switch":
+            widget.valueOn = config['valueOn']
+            widget.valueOff = config['valueOff']
+            widget.shortcut.setKey(config['shortcut'])
+        elif config['widgetType'] == "Slider":
+            widget.minSlider = config['minSlider']
+            widget.maxSlider = config['maxSlider']
+            widget.stepSlider = config['stepSlider']
+            widget.shortcutPlus.setKey(config['shortcutPlus'])
+            widget.shortcutMinus.setKey(config['shortcutMinus'])
+        self._experiments[idx]['Remote'][config['name']] = config
+        widget.updateData()
 
-    def remoteAddWidget(self, msg=None, **kwargs):
+    def remoteAddWidget(self, config=None, **kwargs):
         """
         Adds a new widget to the remoteDock
-        :param msg: RemoteWidgetEdit object containing widget parameters and information
+        :param config: RemoteWidgetEdit object containing widget parameters and information
         """
         changed = False
         idx = self.experimentList.row(self._currentExpListItem)
-        if not msg:
-            exp = self.exp.getExperiment()
-            del exp['Name']
-            msg, ok = RemoteWidgetEdit.getData(exp=exp, **kwargs)
+        exp = self.exp.getExperiment()
+        del exp['Name']
+        if not config:
+            config, ok = RemoteWidgetEdit.getData(exp=exp, **kwargs)
             if not ok:
                 return
-            else:
-                changed = True
-                if not 'Remote' in self._experiments[idx]:
-                    self._experiments[idx]['Remote'] = {}
-                self._experiments[idx]['Remote'][msg['name']] = {}
+            changed = True
+            if not 'Remote' in self._experiments[idx]:
+                self._experiments[idx]['Remote'] = {}
+            self._experiments[idx]['Remote'][config['name']] = {}
 
         if changed:
-            self._experiments[idx]['Remote'][msg['name']]['widgetType'] = msg['widgetType']
-            self._experiments[idx]['Remote'][msg['name']]['Module'] = msg['module']
-            self._experiments[idx]['Remote'][msg['name']]['Parameter'] = msg['parameter']
+            self._experiments[idx]['Remote'][config['name']] = config
         sliderLabel = None
-        if msg['widgetType'] == "PushButton":
-            widget = MovablePushButton(msg['name'], msg['valueOn'], msg['shortcut'], module=msg['module'],
-                                       parameter=msg['parameter'])
+        if config['widgetType'] == "PushButton":
+            widget = MovablePushButton(config['name'], config['valueOn'], config['shortcut'], module=config['Module'],
+                                       parameter=config['Parameter'])
             widget.setFixedHeight(40)
             widget.setFixedWidth(100)
             widget.clicked.connect(lambda: self.remotePushButtonSendParameter(widget))
             widget.editAction.triggered.connect(lambda _: self.remoteConfigWidget(
                 widget, editWidget=True))
             widget.removeAction.triggered.connect(lambda _: self.remoteRemoveWidget(widget))
-            if changed:
-                self._experiments[idx]['Remote'][msg['name']]['shortcut'] = msg['shortcut']
-                self._experiments[idx]['Remote'][msg['name']]['valueOn'] = msg['valueOn']
-        elif msg['widgetType'] == "Switch":
-            widget = MovableSwitch(msg['name'], msg['valueOn'], msg['valueOff'], msg['shortcut'], module=msg['module'],
-                                   parameter=msg['parameter'])
+        elif config['widgetType'] == "Switch":
+            widget = MovableSwitch(config['name'], config['valueOn'], config['valueOff'], config['shortcut'], module=config['Module'],
+                                   parameter=config['Parameter'])
             widget.setFixedHeight(40)
             widget.setFixedWidth(100)
             widget.clicked.connect(lambda: self.remoteSwitchSendParameter(widget))
             widget.editAction.triggered.connect(lambda _: self.remoteConfigWidget(
                 widget, editWidget=True))
             widget.removeAction.triggered.connect(lambda _: self.remoteRemoveWidget(widget))
-            if changed:
-                self._experiments[idx]['Remote'][msg['name']]['shortcut'] = msg['shortcut']
-                self._experiments[idx]['Remote'][msg['name']]['valueOn'] = msg['valueOn']
-                self._experiments[idx]['Remote'][msg['name']]['valueOff'] = msg['valueOff']
-        elif msg['widgetType'] == "Slider":
+        elif config['widgetType'] == "Slider":
             sliderLabel = QLabel()
             sliderLabel.setFixedHeight(15)
             labelFont = sliderLabel.font()
             labelFont.setPointSize(8)
             sliderLabel.setFont(labelFont)
             self.remoteWidgetLayout.addWidget(sliderLabel)
-            widget = MovableSlider(msg['name'], msg['minSlider'], msg['maxSlider'], msg['stepSlider'],
-                                   sliderLabel, msg['shortcutPlus'], msg['shortcutMinus'], msg['startValue'],
-                                   module=msg['module'],
-                                   parameter=msg['parameter'])
+            widget = MovableSlider(config['name'], config['minSlider'], config['maxSlider'], config['stepSlider'],
+                                   sliderLabel, config['shortcutPlus'], config['shortcutMinus'], exp[config['Module']][config['Parameter']],
+                                   module=config['Module'],
+                                   parameter=config['Parameter'])
             widget.setFixedHeight(30)
             widget.setFixedWidth(200)
             widget.valueChanged.connect(lambda value: self.remoteSliderSendParameter(widget, value))
@@ -1588,12 +1545,6 @@ class MainGui(QMainWindow):
             widget.editAction.triggered.connect(lambda _: self.remoteConfigWidget(
                 widget, editWidget=True))
             widget.removeAction.triggered.connect(lambda _, widget=widget: self.remoteRemoveWidget(widget))
-            if changed:
-                self._experiments[idx]['Remote'][msg['name']]['shortcutPlus'] = msg['shortcutPlus']
-                self._experiments[idx]['Remote'][msg['name']]['shortcutMinus'] = msg['shortcutMinus']
-                self._experiments[idx]['Remote'][msg['name']]['minSlider'] = msg['minSlider']
-                self._experiments[idx]['Remote'][msg['name']]['maxSlider'] = msg['maxSlider']
-                self._experiments[idx]['Remote'][msg['name']]['stepSlider'] = msg['stepSlider']
         else:
             return
         if self.remoteWidget.rect().contains((self.remoteWidgetLayout.count() % 2) * 200,
@@ -1650,28 +1601,30 @@ class MainGui(QMainWindow):
                     if wid.module == widget.module and wid.parameter == widget.parameter:
                         wid.setValue(float(value))
                         wid.valueOn = value
-                        wid.label.setText(wid.widgetName + ': ' + "{:.3f}".format(wid.value))
+                        wid.label.setText(wid.widgetName + ": {:.3f}".format(wid.value))
         else:
             widget.valueOn = value
 
             if isinstance(widget, MovableSlider):
                 value = widget.calcValue(value)
 
-            widget.label.setText(widget.widgetName + ': ' + "{:.3f}".format(value))
+            widget.label.setText(widget.widgetName + ": {:.3f}".format(value))
 
     def remoteSendParamter(self, module, parameter, value):
         exp = deepcopy(self.exp.getExperiment())
         del exp['Name']
 
         for key, val in exp.items():
-            if key == module:
-                for k, v in val.items():
-                    if k == parameter:
-                        exp[key][k] = value
-                        self.exp.editExperiment(exp)
-                        if self.actSendParameter.isEnabled():
-                            self.sendParameter()
-                        return
+            if key != module:
+                continue
+            for k, v in val.items():
+                if k != parameter:
+                    continue
+                exp[key][k] = value
+                self.exp.editExperiment(exp)
+                if self.actSendParameter.isEnabled():
+                    self.sendParameter()
+                return
 
     def copyRemoteSource(self):
         text = "  Remote:\n"

--- a/pywisp/utils.py
+++ b/pywisp/utils.py
@@ -439,8 +439,8 @@ class RemoteWidgetEdit(QDialog):
         self.shortcutPlus = str(kwargs.get('shortcutPlus', ""))
         self.shortcutMinus = str(kwargs.get('shortcutMinus', ""))
 
-        self.curModule = kwargs.get('module', None)
-        self.curParameter = kwargs.get('parameter', None)
+        self.curModule = kwargs.get('Module', None)
+        self.curParameter = kwargs.get('Parameter', None)
 
         self.editWidget = editWidget
 
@@ -586,8 +586,8 @@ class RemoteWidgetEdit(QDialog):
         msg = dict()
         msg['name'] = self.nameText.text()
         msg['widgetType'] = self.typeList.currentText()
-        msg['module'] = self.moduleList.currentText()
-        msg['parameter'] = self.paramList.currentText()
+        msg['Module'] = self.moduleList.currentText()
+        msg['Parameter'] = self.paramList.currentText()
 
         if self.typeList.currentText() == "PushButton":
             msg['valueOn'] = self.valueText.text()
@@ -612,8 +612,8 @@ class RemoteWidgetEdit(QDialog):
         msg = dialog._getData()
 
         if msg['widgetType'] == "Slider":
-            if msg['parameter'] in exp[msg['module']]:
-                msg['startValue'] = exp[msg['module']][msg['parameter']]
+            if msg['Parameter'] in exp[msg['Module']]:
+                msg['startValue'] = exp[msg['Module']][msg['Parameter']]
             else:
                 msg['startValue'] = 0
 
@@ -740,8 +740,8 @@ class MovablePushButton(QPushButton, MovableWidget):
         data['widgetType'] = 'PushButton'
         data['name'] = self.widgetName
         data['valueOn'] = self.valueOn
-        data['module'] = self.module
-        data['parameter'] = self.parameter
+        data['Module'] = self.module
+        data['Parameter'] = self.parameter
         data['shortcut'] = self.shortcut.key().toString()
 
         return data
@@ -839,8 +839,8 @@ class MovableSlider(DoubleSlider, MovableWidget):
         data['minSlider'] = self.minSlider
         data['maxSlider'] = self.maxSlider
         data['stepSlider'] = self.stepSlider
-        data['module'] = self.module
-        data['parameter'] = self.parameter
+        data['Module'] = self.module
+        data['Parameter'] = self.parameter
         data['shortcutPlus'] = self.shortcutPlus.key().toString()
         data['shortcutMinus'] = self.shortcutMinus.key().toString()
 
@@ -883,8 +883,8 @@ class MovableSwitch(QPushButton, MovableWidget):
         data['name'] = self.widgetName
         data['valueOn'] = self.valueOn
         data['valueOff'] = self.valueOff
-        data['module'] = self.module
-        data['parameter'] = self.parameter
+        data['Module'] = self.module
+        data['Parameter'] = self.parameter
         data['shortcut'] = self.shortcut.key().toString()
 
         return data


### PR DESCRIPTION
simplify remote code, and make all configs optional. if they don't exist the defaults will be used.

* Heartbeat timeout config is now called HeartbeatTime (but the code will warn you if you configured something incorrectly)
  example:
```log
08/09/2020 16:13:01 - MainGui - WARNING - Experiment config key 'Heartbeat' does not exist.
                Possible keys: ['TimerTime', 'HeartbeatTime', 'InterpolationPoints', 'MovingWindowEnable', 'MovingWindowSize']
```

* also fixes startValue issue for slider.

i tried to test this as much as possible, hope i didn't include any regressions.

this seems to work well for me.