### PR TITLE
Remotedock

### DIFF
--- a/pywisp/gui.py
+++ b/pywisp/gui.py
@@ -1416,6 +1416,7 @@ class MainGui(QMainWindow):
         """
         self.actStartExperiment.setDisabled(True)
         self.selectedExp = False
+        self.remoteWidgetLayout.clearAll()
 
         expName = str(item.text())
         self._currentLastMeasItem = item

--- a/pywisp/gui.py
+++ b/pywisp/gui.py
@@ -1571,12 +1571,10 @@ class MainGui(QMainWindow):
             widget.removeAction.triggered.connect(lambda _, widget=widget: self.remoteRemoveWidget(widget))
         else:
             return
-        if self.remoteWidget.rect().contains((self.remoteWidgetLayout.count() % 2) * 200,
-                                             (self.remoteWidgetLayout.count() // 2) * 40):
-            widget.move((self.remoteWidgetLayout.count() % 2) * 200, (self.remoteWidgetLayout.count() // 2) * 40)
-            if sliderLabel:
-                sliderLabel.move((self.remoteWidgetLayout.count() % 2) * 200 + 80,
-                                 (self.remoteWidgetLayout.count() // 2) * 40 + 30)
+        widget.move((self.remoteWidgetLayout.count() % 2) * 200, (self.remoteWidgetLayout.count() // 2) * 40)
+        if sliderLabel:
+            sliderLabel.move((self.remoteWidgetLayout.count() % 2) * 200 + 80,
+                             (self.remoteWidgetLayout.count() // 2) * 40 + 30)
         self.remoteWidgetLayout.addWidget(widget)
 
     def remotePushButtonSendParameter(self, widget):


### PR DESCRIPTION
Bisher war es so, dass wenn die remote widgets beim Hinzufügen nicht genug platz im sichtbaren Bereich des remote docks hatten, diese nicht hinzugefügt wurden. Das bedeutete auch, dass wenn man anschließend das Fenster oder das Dock vergrößerte, diese immernoch nicht vorhanden waren. So wie jetzt werden alle hinzugefügt und nur die, die im sichtbaren Bereich platz haben sieht man, wenn man diesen Bereich aber irgendwie vergrößert kommen auch die verdeckten zum Vorschein.

Der zweite Commit blendet alle remote widgets aus sobald eine Messung geladen wird. Bisher war es so, dass die remote widgets des zuletzt durchgeführten Experiments bestehen blieben, auch wenn diese mit dem geladenen  Experiment gar nichts zu tun hatten. issue #107 