### PR TITLE
slider: don't check bounds

### DIFF
--- a/pywisp/utils.py
+++ b/pywisp/utils.py
@@ -804,7 +804,6 @@ class MovablePushButton(QPushButton, MovableWidget):
 
 
 class DoubleSlider(QSlider):
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -828,17 +827,11 @@ class DoubleSlider(QSlider):
         super().setValue(int(round((value - self._minValue) / self._stepSize, 8)))
 
     def setMinimum(self, value):
-        if value > self._maxValue:
-            raise ValueError("Minimum limit cannot be higher than maximum")
-
         self._minValue = value
         super().setMinimum(0)
         super().setMaximum(int((self._maxValue - self._minValue) / self._stepSize))
 
     def setMaximum(self, value):
-        if value < self._minValue:
-            raise ValueError("Minimum limit cannot be higher than maximum")
-
         self._maxValue = value
         super().setMinimum(0)
         super().setMaximum(int((self._maxValue - self._minValue) / self._stepSize))


### PR DESCRIPTION
we set bounds sequentially, which would previously break any slider with
a min val > 1

possible fix for #123 