### PR TITLE
bugfixes und neue settings.json für versch. gamepads

### DIFF
--- a/examples/tcp/pc/client/xoutput-settings.json
+++ b/examples/tcp/pc/client/xoutput-settings.json
@@ -5,7 +5,7 @@
   "DisableAutoRefresh": false,
   "Language": "English",
   "Input": {
-    "b930b2f0-ca00-11ec-8001-444553540000": {
+    "a93815c0-d057-11ec-8001-444553540000": {
       "ForceFeedback": false
     },
     "Keyboard": {
@@ -13,19 +13,22 @@
     },
     "Mouse": {
       "ForceFeedback": false
+    },
+    "f42721d0-d691-11ec-8001-444553540000": {
+      "ForceFeedback": false
     }
   },
   "Mapping": [
     {
       "StartWhenConnected": false,
-      "Name": "Controller",
-      "Id": "2e9a7e02-80af-4d61-8379-1086a76656af",
+      "Name": "Gamepad_axxxxx",
+      "Id": "36eb56ac-d52e-408a-8dad-4e5fbc447097",
       "ForceFeedbackDevice": null,
       "Mappings": {
         "A": {
           "Mappers": [
             {
-              "InputDevice": "b930b2f0-ca00-11ec-8001-444553540000",
+              "InputDevice": "a93815c0-d057-11ec-8001-444553540000",
               "InputType": "26",
               "MinValue": 0.0,
               "MaxValue": 1.0,
@@ -37,7 +40,7 @@
         "B": {
           "Mappers": [
             {
-              "InputDevice": "b930b2f0-ca00-11ec-8001-444553540000",
+              "InputDevice": "a93815c0-d057-11ec-8001-444553540000",
               "InputType": "25",
               "MinValue": 0.0,
               "MaxValue": 1.0,
@@ -49,7 +52,7 @@
         "X": {
           "Mappers": [
             {
-              "InputDevice": "b930b2f0-ca00-11ec-8001-444553540000",
+              "InputDevice": "a93815c0-d057-11ec-8001-444553540000",
               "InputType": "27",
               "MinValue": 0.0,
               "MaxValue": 1.0,
@@ -61,7 +64,7 @@
         "Y": {
           "Mappers": [
             {
-              "InputDevice": "b930b2f0-ca00-11ec-8001-444553540000",
+              "InputDevice": "a93815c0-d057-11ec-8001-444553540000",
               "InputType": "24",
               "MinValue": 0.0,
               "MaxValue": 1.0,
@@ -73,7 +76,7 @@
         "L1": {
           "Mappers": [
             {
-              "InputDevice": "b930b2f0-ca00-11ec-8001-444553540000",
+              "InputDevice": "a93815c0-d057-11ec-8001-444553540000",
               "InputType": "28",
               "MinValue": 0.0,
               "MaxValue": 1.0,
@@ -85,7 +88,7 @@
         "R1": {
           "Mappers": [
             {
-              "InputDevice": "b930b2f0-ca00-11ec-8001-444553540000",
+              "InputDevice": "a93815c0-d057-11ec-8001-444553540000",
               "InputType": "29",
               "MinValue": 0.0,
               "MaxValue": 1.0,
@@ -97,8 +100,8 @@
         "L3": {
           "Mappers": [
             {
-              "InputDevice": "b930b2f0-ca00-11ec-8001-444553540000",
-              "InputType": "30",
+              "InputDevice": "a93815c0-d057-11ec-8001-444553540000",
+              "InputType": "34",
               "MinValue": 0.0,
               "MaxValue": 1.0,
               "Deadzone": 0.0
@@ -109,8 +112,8 @@
         "R3": {
           "Mappers": [
             {
-              "InputDevice": "b930b2f0-ca00-11ec-8001-444553540000",
-              "InputType": "31",
+              "InputDevice": "a93815c0-d057-11ec-8001-444553540000",
+              "InputType": "35",
               "MinValue": 0.0,
               "MaxValue": 1.0,
               "Deadzone": 0.0
@@ -121,7 +124,7 @@
         "Start": {
           "Mappers": [
             {
-              "InputDevice": "b930b2f0-ca00-11ec-8001-444553540000",
+              "InputDevice": "a93815c0-d057-11ec-8001-444553540000",
               "InputType": "33",
               "MinValue": 0.0,
               "MaxValue": 1.0,
@@ -133,6 +136,18 @@
         "Back": {
           "Mappers": [
             {
+              "InputDevice": "a93815c0-d057-11ec-8001-444553540000",
+              "InputType": "32",
+              "MinValue": 0.0,
+              "MaxValue": 1.0,
+              "Deadzone": 0.0
+            }
+          ],
+          "CenterPoint": 0.0
+        },
+        "Home": {
+          "Mappers": [
+            {
               "InputDevice": null,
               "InputType": "0",
               "MinValue": 0.0,
@@ -142,22 +157,10 @@
           ],
           "CenterPoint": 0.0
         },
-        "Home": {
-          "Mappers": [
-            {
-              "InputDevice": "Mouse",
-              "InputType": "0",
-              "MinValue": 0.0,
-              "MaxValue": 1.0,
-              "Deadzone": 0.0
-            }
-          ],
-          "CenterPoint": 0.0
-        },
         "LX": {
           "Mappers": [
             {
-              "InputDevice": "b930b2f0-ca00-11ec-8001-444553540000",
+              "InputDevice": "a93815c0-d057-11ec-8001-444553540000",
               "InputType": "4",
               "MinValue": 0.0,
               "MaxValue": 1.0,
@@ -169,7 +172,7 @@
         "LY": {
           "Mappers": [
             {
-              "InputDevice": "b930b2f0-ca00-11ec-8001-444553540000",
+              "InputDevice": "a93815c0-d057-11ec-8001-444553540000",
               "InputType": "0",
               "MinValue": 0.0,
               "MaxValue": 1.0,
@@ -181,7 +184,7 @@
         "RX": {
           "Mappers": [
             {
-              "InputDevice": "b930b2f0-ca00-11ec-8001-444553540000",
+              "InputDevice": "a93815c0-d057-11ec-8001-444553540000",
               "InputType": "12",
               "MinValue": 0.0,
               "MaxValue": 1.0,
@@ -193,10 +196,10 @@
         "RY": {
           "Mappers": [
             {
-              "InputDevice": "b930b2f0-ca00-11ec-8001-444553540000",
+              "InputDevice": "a93815c0-d057-11ec-8001-444553540000",
               "InputType": "8",
-              "MinValue": 0.0,
-              "MaxValue": 1.0,
+              "MinValue": 1.0,
+              "MaxValue": 0.0,
               "Deadzone": 0.0
             }
           ],
@@ -205,10 +208,10 @@
         "L2": {
           "Mappers": [
             {
-              "InputDevice": null,
-              "InputType": "0",
+              "InputDevice": "a93815c0-d057-11ec-8001-444553540000",
+              "InputType": "30",
               "MinValue": 0.0,
-              "MaxValue": 0.0,
+              "MaxValue": 1.0,
               "Deadzone": 0.0
             }
           ],
@@ -217,10 +220,10 @@
         "R2": {
           "Mappers": [
             {
-              "InputDevice": null,
-              "InputType": "0",
+              "InputDevice": "a93815c0-d057-11ec-8001-444553540000",
+              "InputType": "31",
               "MinValue": 0.0,
-              "MaxValue": 0.0,
+              "MaxValue": 1.0,
               "Deadzone": 0.0
             }
           ],
@@ -229,7 +232,7 @@
         "UP": {
           "Mappers": [
             {
-              "InputDevice": "b930b2f0-ca00-11ec-8001-444553540000",
+              "InputDevice": "a93815c0-d057-11ec-8001-444553540000",
               "InputType": "1000",
               "MinValue": 0.0,
               "MaxValue": 1.0,
@@ -241,7 +244,7 @@
         "DOWN": {
           "Mappers": [
             {
-              "InputDevice": "b930b2f0-ca00-11ec-8001-444553540000",
+              "InputDevice": "a93815c0-d057-11ec-8001-444553540000",
               "InputType": "1001",
               "MinValue": 0.0,
               "MaxValue": 1.0,
@@ -253,7 +256,7 @@
         "LEFT": {
           "Mappers": [
             {
-              "InputDevice": "b930b2f0-ca00-11ec-8001-444553540000",
+              "InputDevice": "a93815c0-d057-11ec-8001-444553540000",
               "InputType": "1002",
               "MinValue": 0.0,
               "MaxValue": 1.0,
@@ -265,7 +268,267 @@
         "RIGHT": {
           "Mappers": [
             {
-              "InputDevice": "b930b2f0-ca00-11ec-8001-444553540000",
+              "InputDevice": "a93815c0-d057-11ec-8001-444553540000",
+              "InputType": "1003",
+              "MinValue": 0.0,
+              "MaxValue": 1.0,
+              "Deadzone": 0.0
+            }
+          ],
+          "CenterPoint": 0.0
+        }
+      }
+    },
+    {
+      "StartWhenConnected": false,
+      "Name": "Gamepad_fxxxxx",
+      "Id": "abeda76f-4fc6-46c9-a4f1-8b6bddc40d46",
+      "ForceFeedbackDevice": null,
+      "Mappings": {
+        "A": {
+          "Mappers": [
+            {
+              "InputDevice": "f42721d0-d691-11ec-8001-444553540000",
+              "InputType": "26",
+              "MinValue": 0.0,
+              "MaxValue": 1.0,
+              "Deadzone": 0.0
+            }
+          ],
+          "CenterPoint": 0.0
+        },
+        "B": {
+          "Mappers": [
+            {
+              "InputDevice": "f42721d0-d691-11ec-8001-444553540000",
+              "InputType": "25",
+              "MinValue": 0.0,
+              "MaxValue": 1.0,
+              "Deadzone": 0.0
+            }
+          ],
+          "CenterPoint": 0.0
+        },
+        "X": {
+          "Mappers": [
+            {
+              "InputDevice": "f42721d0-d691-11ec-8001-444553540000",
+              "InputType": "27",
+              "MinValue": 0.0,
+              "MaxValue": 1.0,
+              "Deadzone": 0.0
+            }
+          ],
+          "CenterPoint": 0.0
+        },
+        "Y": {
+          "Mappers": [
+            {
+              "InputDevice": "f42721d0-d691-11ec-8001-444553540000",
+              "InputType": "24",
+              "MinValue": 0.0,
+              "MaxValue": 1.0,
+              "Deadzone": 0.0
+            }
+          ],
+          "CenterPoint": 0.0
+        },
+        "L1": {
+          "Mappers": [
+            {
+              "InputDevice": "f42721d0-d691-11ec-8001-444553540000",
+              "InputType": "28",
+              "MinValue": 0.0,
+              "MaxValue": 1.0,
+              "Deadzone": 0.0
+            }
+          ],
+          "CenterPoint": 0.0
+        },
+        "R1": {
+          "Mappers": [
+            {
+              "InputDevice": "f42721d0-d691-11ec-8001-444553540000",
+              "InputType": "29",
+              "MinValue": 0.0,
+              "MaxValue": 1.0,
+              "Deadzone": 0.0
+            }
+          ],
+          "CenterPoint": 0.0
+        },
+        "L3": {
+          "Mappers": [
+            {
+              "InputDevice": "f42721d0-d691-11ec-8001-444553540000",
+              "InputType": "34",
+              "MinValue": 0.0,
+              "MaxValue": 1.0,
+              "Deadzone": 0.0
+            }
+          ],
+          "CenterPoint": 0.0
+        },
+        "R3": {
+          "Mappers": [
+            {
+              "InputDevice": "f42721d0-d691-11ec-8001-444553540000",
+              "InputType": "35",
+              "MinValue": 0.0,
+              "MaxValue": 1.0,
+              "Deadzone": 0.0
+            }
+          ],
+          "CenterPoint": 0.0
+        },
+        "Start": {
+          "Mappers": [
+            {
+              "InputDevice": "f42721d0-d691-11ec-8001-444553540000",
+              "InputType": "33",
+              "MinValue": 0.0,
+              "MaxValue": 1.0,
+              "Deadzone": 0.0
+            }
+          ],
+          "CenterPoint": 0.0
+        },
+        "Back": {
+          "Mappers": [
+            {
+              "InputDevice": "f42721d0-d691-11ec-8001-444553540000",
+              "InputType": "32",
+              "MinValue": 0.0,
+              "MaxValue": 1.0,
+              "Deadzone": 0.0
+            }
+          ],
+          "CenterPoint": 0.0
+        },
+        "Home": {
+          "Mappers": [
+            {
+              "InputDevice": null,
+              "InputType": "0",
+              "MinValue": 0.0,
+              "MaxValue": 0.0,
+              "Deadzone": 0.0
+            }
+          ],
+          "CenterPoint": 0.0
+        },
+        "LX": {
+          "Mappers": [
+            {
+              "InputDevice": "f42721d0-d691-11ec-8001-444553540000",
+              "InputType": "4",
+              "MinValue": 0.0,
+              "MaxValue": 1.0,
+              "Deadzone": 0.0
+            }
+          ],
+          "CenterPoint": 0.0
+        },
+        "LY": {
+          "Mappers": [
+            {
+              "InputDevice": "f42721d0-d691-11ec-8001-444553540000",
+              "InputType": "0",
+              "MinValue": 0.0,
+              "MaxValue": 1.0,
+              "Deadzone": 0.0
+            }
+          ],
+          "CenterPoint": 0.0
+        },
+        "RX": {
+          "Mappers": [
+            {
+              "InputDevice": "f42721d0-d691-11ec-8001-444553540000",
+              "InputType": "12",
+              "MinValue": 0.0,
+              "MaxValue": 1.0,
+              "Deadzone": 0.0
+            }
+          ],
+          "CenterPoint": 0.0
+        },
+        "RY": {
+          "Mappers": [
+            {
+              "InputDevice": "f42721d0-d691-11ec-8001-444553540000",
+              "InputType": "8",
+              "MinValue": 1.0,
+              "MaxValue": 0.0,
+              "Deadzone": 0.0
+            }
+          ],
+          "CenterPoint": 0.0
+        },
+        "L2": {
+          "Mappers": [
+            {
+              "InputDevice": "f42721d0-d691-11ec-8001-444553540000",
+              "InputType": "30",
+              "MinValue": 0.0,
+              "MaxValue": 1.0,
+              "Deadzone": 0.0
+            }
+          ],
+          "CenterPoint": 0.0
+        },
+        "R2": {
+          "Mappers": [
+            {
+              "InputDevice": "f42721d0-d691-11ec-8001-444553540000",
+              "InputType": "31",
+              "MinValue": 0.0,
+              "MaxValue": 1.0,
+              "Deadzone": 0.0
+            }
+          ],
+          "CenterPoint": 0.0
+        },
+        "UP": {
+          "Mappers": [
+            {
+              "InputDevice": "f42721d0-d691-11ec-8001-444553540000",
+              "InputType": "1000",
+              "MinValue": 0.0,
+              "MaxValue": 1.0,
+              "Deadzone": 0.0
+            }
+          ],
+          "CenterPoint": 0.0
+        },
+        "DOWN": {
+          "Mappers": [
+            {
+              "InputDevice": "f42721d0-d691-11ec-8001-444553540000",
+              "InputType": "1001",
+              "MinValue": 0.0,
+              "MaxValue": 1.0,
+              "Deadzone": 0.0
+            }
+          ],
+          "CenterPoint": 0.0
+        },
+        "LEFT": {
+          "Mappers": [
+            {
+              "InputDevice": "f42721d0-d691-11ec-8001-444553540000",
+              "InputType": "1002",
+              "MinValue": 0.0,
+              "MaxValue": 1.0,
+              "Deadzone": 0.0
+            }
+          ],
+          "CenterPoint": 0.0
+        },
+        "RIGHT": {
+          "Mappers": [
+            {
+              "InputDevice": "f42721d0-d691-11ec-8001-444553540000",
               "InputType": "1003",
               "MinValue": 0.0,
               "MaxValue": 1.0,

--- a/pywisp/gamepad.py
+++ b/pywisp/gamepad.py
@@ -120,7 +120,7 @@ class GamePad(QThread):
         # sends number between -0.5 and 0.5 for abs values
         for key, value in self.absState.items():
             sig = getattr(self, 'abs' + key)
-            sig.emit(self.absState[key] / self.stickResolution)
+            sig.emit(round(self.absState[key] / self.stickResolution, 3)) # BUGFIX: damit maximalwerte am slider erreicht werden können
 
     def run(self):
         while self.runFlag:

--- a/pywisp/utils.py
+++ b/pywisp/utils.py
@@ -911,16 +911,13 @@ class MovableSlider(DoubleSlider, MovableWidget):
                     name = list(ctrlDict.keys())[list(ctrlDict.values()).index(self.shortcutKeyGp)]
                     if 'Absolute' in name:
                         name = 'abs' + self.shortcutKeyGp
+                        sliderDim = float(self.maxSlider) - float(self.minSlider)
                         if self.invertSlider is None or self.invertSlider == False:
                             getattr(self.gamepad, name).connect(lambda absVal:
-                                                                self.setValue(absVal *
-                                                                              ((float(self.maxSlider) -
-                                                                                float(self.minSlider)))))
+                                                                self.setValue(absVal * sliderDim))
                         else:
                             getattr(self.gamepad, name).connect(lambda absVal:
-                                                                self.setValue(-absVal *
-                                                                              ((float(self.maxSlider) -
-                                                                                float(self.minSlider)))))
+                                                                self.setValue(-absVal *sliderDim))
                     else:
                         self._logger.error("{} is not an absolute button!".format(self.shortcutKeyGp))
                 except ValueError:


### PR DESCRIPTION
hab festgestellt, dass es am simpelsten ist wenn man einfach aus den zwei Controllern in XOutput auswählt. Der Funktionierende leuchtet ja sowieso Grün auf.
Habe versucht, das ganze dynamisch in PyWisp zu anzupassen, doch war nicht erfolgreich da XOutput ja außerhalb überall liegen kann. 

Sonst habe ich alles ausgiebig getestet und einen kleineren bug beseitigt. Ich konnte keine weiteren Fehler finden.