### PR TITLE
Removed MAX_PAYLOAD since it's already defined in frame.h

### DIFF
--- a/examples/tcp/bur/server/Logical/Libraries/Comm.h
+++ b/examples/tcp/bur/server/Logical/Libraries/Comm.h
@@ -6,8 +6,6 @@
 
 #include "Transport/Frame.h"
 
-#define MAX_PAYLOAD (80)
-
 /**
  * @class Comm
  * @brief defines an interface class which lets the TcpIpServer communicate with the transport protocol


### PR DESCRIPTION
Removed the double define of MAX_PAYLOAD.
I think its better to keep it in _frames.h_ rather then in _comm.h_, because all the frame specific code is there.