### PR TITLE
example/generic/server: update for latest tool-libs changes

### DIFF
--- a/examples/generic/server/CMakeLists.txt
+++ b/examples/generic/server/CMakeLists.txt
@@ -20,15 +20,14 @@ find_package(Eigen3 3.3 REQUIRED NO_MODULE)
 
 add_custom_command(
     OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/inc/doublependulum.h
-    COMMAND python codegen.py 
+    COMMAND python codegen.py
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/settings.py
             ${CMAKE_CURRENT_SOURCE_DIR}/codegen.py
     VERBATIM
     )
 
-add_executable(${PROJECT_NAME} src/server.cpp
-    inc/doublependulum.h)
+add_executable(${PROJECT_NAME} src/server.cpp inc/doublependulum.h)
 
 target_include_directories(${PROJECT_NAME} PUBLIC inc)
 target_link_libraries(${PROJECT_NAME}
@@ -37,6 +36,6 @@ target_link_libraries(${PROJECT_NAME}
     Eigen3::Eigen)
 add_custom_target(run
     DEPENDS ${PROJECT_NAME}
-    COMMAND ncat -lkuvv4 127.0.0.1 45670 -c ./${PROJECT_NAME}
+    COMMAND ./${PROJECT_NAME}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )

--- a/examples/generic/server/inc/model.h
+++ b/examples/generic/server/inc/model.h
@@ -27,7 +27,7 @@ struct Trajectory {
     LinearTrajectory interp{};
     operator Reference&() { return ref; }
     void step(uint32_t time, uint32_t) {
-        ref(0) = interp(time/1000.);
+        ref(0) = interp(time/1000.)[0];
     }
 };
 
@@ -66,7 +66,7 @@ struct Model {
 
     }
     void getTrajData(Frame &f) {
-        static SeriesUnpacker su;
+        static SeriesUnpacker<double> su;
         auto buf = su.unpack(f);
         if (buf) {
             traj.interp.setData(std::move(*buf));

--- a/examples/generic/server/settings.py
+++ b/examples/generic/server/settings.py
@@ -18,5 +18,5 @@ pendulum2Mass = 0.1                         # kg
 pendulum1Length = 0.25                      # m
 pendulum2Length = 0.25                      # m
 
-pendulum1Inertia = 4.0 / 3.0 * pendulum1Mass * pendulum1Length ** 2  
-pendulum2Inertia = 4.0 / 3.0 * pendulum2Mass * pendulum2Length ** 2 
+pendulum1Inertia = 4.0 / 3.0 * pendulum1Mass * pendulum1Length ** 2
+pendulum2Inertia = 4.0 / 3.0 * pendulum2Mass * pendulum2Length ** 2

--- a/examples/generic/server/src/server.cpp
+++ b/examples/generic/server/src/server.cpp
@@ -2,7 +2,7 @@
  *
  * Copyright (c) 2023 IACE
  */
-#include <linux/host.h>
+#include <sys/comm.h>
 #include <cstdlib>
 #include <core/experiment.h>
 #include "model.h"
@@ -10,6 +10,9 @@
 #include "comm/min.h"
 #include "comm/bufferutils.h"
 #include "comm/line.h"
+
+TTY tty{"/dev/tty"};
+UDP udp{"127.0.0.1", 45670};
 
 struct Support {
     Support();
@@ -19,8 +22,8 @@ struct Support {
 };
 
 Support::Support()
-    : lineout{host.tty.out}
-    , min{.in = host.socket.in, .out = host.socket.out}
+    : lineout{tty}
+    , min{.in = udp, .out = udp}
 {}
 void Support::init() {
     /* e.setHeartbeatTimeout(500, min.out); */
@@ -41,7 +44,6 @@ void Support::init() {
 Kernel k;
 Support support;
 Experiment e{&support.min.reg};
-ExpLog elog{e, k.log};
 
 int main() {
     support.init();


### PR DESCRIPTION
- use <sys/comm.h> instead of deprecated <linux/host.h>
- ExpLog is part of experiment now
- trajectory returns list instead of value
- SeriesUnpacker is now a template
- no need for external 'ncat' anymore

fixes #141