### PR TITLE
connection: rework incoming min stream unpacking

### DIFF
--- a/pywisp/connection.py
+++ b/pywisp/connection.py
@@ -10,7 +10,7 @@ from abc import abstractmethod
 import serial
 from PyQt5.QtCore import QObject, QThread, pyqtSignal
 
-from .min import Packer, Unpacker, Frame, Bytewise
+from .min import Packer, Unpacker, Frame, Bytewise, HDRStuf
 from .utils import coroutine, pipe
 
 __all__ = ["Connection", "UdpConnection", "TcpConnection", "SerialConnection", "IACEConnection"]
@@ -39,7 +39,7 @@ class ConnReader(QObject):
                 pass
             except Exception as e:
                 if not self.stop:
-                    self.err.emit(f"connection dropped: {e}")
+                    self.err.emit(f"connection dropped: {repr(e)} / {e}")
                 break
 
     def quit(self):
@@ -239,7 +239,7 @@ class UdpConnection(SocketConnection):
 
     def __init__(self, ip, port, **kwargs):
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        super().__init__(sock, ip, port, tx=Packer, rx=[Bytewise, Unpacker], **kwargs)
+        super().__init__(sock, ip, port, tx=Packer, rx=[Bytewise, HDRStuf, Unpacker], **kwargs)
 
 class IACEConnection(UdpConnection):
     def __init__(self, *args, **kwargs):

--- a/pywisp/min.py
+++ b/pywisp/min.py
@@ -62,32 +62,61 @@ def Packer(sink):
         sink.send( bytes(ret) )
 
 @coroutine
+def HDRStuf(sink):
+    """ Handle HDR and STF bytes of incoming stream """
+    while True:
+        b1 = (yield)
+        if b1 != HDR:
+            sink.send( (b1, True) )
+            continue
+        b2 = (yield)
+        if b2 != HDR:
+            sink.send( (b1, True) )
+            sink.send( (b2, True) )
+            continue
+        b3 = (yield)
+        if b3 == STF:
+            sink.send( (b1, True) )
+            sink.send( (b2, True) )
+            continue
+        elif b3 == HDR:
+            sink.send( (0, False) )
+            continue
+        else:
+            # something has gone wrong, give up
+            sink.send( (0, False) )
+
+@coroutine
 def Unpacker(sink):
     """ unpack received data from wire into Frame. coroutine """
     while True:
-        if (yield)!= HDR:
+        id, ok = (yield)
+        if not ok: continue
+        if id >= 64: # not handling transport frames
+            # print(f"dropping transport frame: {id=}")
             continue
-        if (yield)!= HDR:
-            continue
-        if (yield)!= HDR:
-            continue
-        id = (yield)
-        assert(id < 64)
-        len = (yield)
-        hdcnt = 0
+        len, ok = (yield)
+        if not ok: continue
         pld = bytearray([])
         for _ in range(len):
-            n = (yield)
+            n, ok = (yield)
+            if not ok: break
             pld.append(n)
-            if n == HDR:
-                hdcnt += 1
-                if hdcnt == 2:
-                    (yield)
-                    hdcnt = 0
-            else:
-                hdcnt = 0
-        crc = bytes([(yield),(yield),(yield),(yield)])
+        if not ok: continue
+        c1, ok = (yield)
+        if not ok: continue
+        c2, ok = (yield)
+        if not ok: continue
+        c3, ok = (yield)
+        if not ok: continue
+        c4, ok = (yield)
+        if not ok: continue
+        crc = bytes([c1,c2,c3,c4])
         want = crc32(bytes([id, len])+pld)
-        if spack('>I',want) != crc:
+        if spack('>I',want) != crc: # dropping frame
+            # print(f"dropping frame mismatched CRC {id=}")
             continue
         sink.send( (id, bytes(pld) ))
+        eof, ok = (yield)
+        if eof != STF: # expected EOF==STF, but don't care
+            pass


### PR DESCRIPTION
this is more correct, handles error cases better, and is able to recover from them

this fixes the dreaded `connection dropped: ` without further info.