### PR TITLE
Improve the documentation

### DIFF
--- a/docs/communication/index.rst
+++ b/docs/communication/index.rst
@@ -54,7 +54,7 @@ Depending on the connection type, currently the following happens:
     end
 
 Note that all actions occur on the machine that PyWisp is running on and no actual
-data is send or received over any channel in this step.
+data is sent or received over any channel in this step.
 
 Powering on the rig
 -------------------
@@ -63,19 +63,22 @@ Powering on the rig
     :caption: Init process of the rig
 
     box "RIG" #LightGreen
-    participant Main
     participant Kernel
     participant Experiment
     participant Model
     end box
 
-    Main -> Main: Support.init()
-    Main -> Main: Model.init()
-    Main -> Kernel: run()
-    loop every 1ms
-        Kernel -> Kernel: Min.poll()
-    end
     note over Experiment: State = IDLE
+    Experiment -> Kernel: register tasks
+    == ==
+    [-> Kernel: register\ncommunication\npolling
+    [-> Model: m.init()
+    Model -> Experiment: register tasks
+    Model -> Experiment: register frame handlers
+    [-> Kernel: k.run()
+    loop every 1ms
+        Kernel -> Kernel: run scheduled tasks
+    end
 
 
 Running an experiment
@@ -94,24 +97,26 @@ Running an experiment
     participant Model
     end box
 
+    !pragma teoz true
+    note over Experiment: State = IDLE
+    &note over PyWisp: runningExperiment = False
+    note over Kernel: run scheduled tasks\nevery 1ms
+    Kernel -> Model: run IDLE tasks
+    == User starts experiment ==
     User -> PyWisp: runExperiment()
-    User <-- PyWisp: Experiment is running
+    note over PyWisp: runningExperiment = True
     PyWisp -> PyWisp: getStartParams()
     PyWisp -> PyWisp: getParams()
     PyWisp -> PyWisp: Append start frame
     PyWisp -> Kernel: Send everything
-    Kernel -> Model: Call handler for each frame
-    Kernel -> Experiment: Call handler for ID 1
+    Kernel -> Model: Communication handler:\nhandle frames
+    Kernel -> Experiment: Communication handler:\nhandle frame ID 1
     note over Experiment: State = RUN
-    Kernel <- Experiment: Schedule INIT EVENT
-    Kernel -> Model: EVENT INIT
-    Model -> Model: reset()
+    Experiment <- Experiment: Event INIT
+    Kernel -> Model: run INIT tasks
     loop
-        Model -> Model: tick()
-        Model -> Model: led.toggle()
-        Model -> Model: sendData()
+    Kernel -> Model: run RUN tasks
     end
-
 
 .. uml::
     :caption: Stopping an experiment
@@ -127,19 +132,23 @@ Running an experiment
     end box
 
     note over Experiment: State = RUN
+    Kernel -> Model: run RUN tasks
 
-    == User interacts ==
+    == User stops experiment ==
 
     User -> PyWisp: stopExperiment()
-    User <-- PyWisp: Experiment is stopped
+    note over PyWisp: runningExperiment = False
     PyWisp -> PyWisp: getStopParams()
     PyWisp -> PyWisp: Append stop frame
-    PyWisp -> Runtime: Send everything
-    Kernel -> Model: Call handler for each frame
-    Kernel -> Experiment: Call handler for ID 1
+    PyWisp -> Kernel: Send everything
+    [<-- PyWisp: emit expFinished
+    Kernel -> Model: Communication handler:\nhandle frames
+    Kernel -> Experiment: Communication handler:\nhandle frame ID 1
     note over Experiment: State = IDLE
-    Kernel <- Experiment: Schedule STOP EVENT
-    Kernel -> Model: EVENT STOP
-    Model -> Model: input.pwm(0)
+    Experiment <- Experiment: Event STOP
+    Kernel -> Model: run STOP tasks
+    loop
+    Kernel -> Model: run IDLE tasks
+    end
 
 Note, that again no messages from the rig to the pc are sent within this action and no failure modes are present.

--- a/docs/communication/index.rst
+++ b/docs/communication/index.rst
@@ -1,2 +1,145 @@
 Communication Diagrams
 ======================
+
+All diagrams on this page are based on the `generic` example.
+The underlying program flow should however only differ slightly on other rigs.
+
+Establishing a connecting
+-------------------------
+
+Depending on the connection type, currently the following happens:
+
+.. uml::
+    :caption: Connecting to a serial port
+
+    box "PC" #LightBlue
+    participant User
+    participant PyWisp
+    participant SerialPort
+    end box
+    box "RIG" #LightGreen
+    participant Runtime
+    end box
+
+    User -> PyWisp: connect()
+    PyWisp -> SerialPort: port.open()
+    alt successful case
+        PyWisp <-- SerialPort: OK
+        User <-- PyWisp: Connection established
+    else failure mode
+        PyWisp <-- SerialPort: Not found
+        User <-- PyWisp: Connection refused
+    end
+
+.. uml::
+    :caption: Connecting to a socket
+
+    box "PC" #LightBlue
+    participant User
+    participant PyWisp
+    participant Socket
+    end box
+    box "RIG" #LightGreen
+    participant Runtime
+    end box
+
+    User -> PyWisp: connect()
+    PyWisp -> Socket: socket.connect()
+    alt successful case
+        PyWisp <-- Socket: True
+        User <-- PyWisp: Connection established
+    else failure mode
+        PyWisp <-- Socket: Error
+        User <-- PyWisp: Connection not possible
+    end
+
+Note that all actions occur on the machine that PyWisp is running on and no actual
+data is send or received over any channel in this step.
+
+Powering on the rig
+-------------------
+
+.. uml::
+    :caption: Init process of the rig
+
+    box "RIG" #LightGreen
+    participant Main
+    participant Kernel
+    participant Experiment
+    participant Model
+    end box
+
+    Main -> Main: Support.init()
+    Main -> Main: Model.init()
+    Main -> Kernel: run()
+    loop every 1ms
+        Kernel -> Kernel: Min.poll()
+    end
+    note over Experiment: State = IDLE
+
+
+Running an experiment
+---------------------
+
+.. uml::
+    :caption: Running an experiment
+
+    box "PC" #LightBlue
+    participant User
+    participant PyWisp
+    end box
+    box "RIG" #LightGreen
+    participant Kernel
+    participant Experiment
+    participant Model
+    end box
+
+    User -> PyWisp: runExperiment()
+    User <-- PyWisp: Experiment is running
+    PyWisp -> PyWisp: getStartParams()
+    PyWisp -> PyWisp: getParams()
+    PyWisp -> PyWisp: Append start frame
+    PyWisp -> Kernel: Send everything
+    Kernel -> Model: Call handler for each frame
+    Kernel -> Experiment: Call handler for ID 1
+    note over Experiment: State = RUN
+    Kernel <- Experiment: Schedule INIT EVENT
+    Kernel -> Model: EVENT INIT
+    Model -> Model: reset()
+    loop
+        Model -> Model: tick()
+        Model -> Model: led.toggle()
+        Model -> Model: sendData()
+    end
+
+
+.. uml::
+    :caption: Stopping an experiment
+
+    box "PC" #LightBlue
+    participant User
+    participant PyWisp
+    end box
+    box "RIG" #LightGreen
+    participant Kernel
+    participant Experiment
+    participant Model
+    end box
+
+    note over Experiment: State = RUN
+
+    == User interacts ==
+
+    User -> PyWisp: stopExperiment()
+    User <-- PyWisp: Experiment is stopped
+    PyWisp -> PyWisp: getStopParams()
+    PyWisp -> PyWisp: Append stop frame
+    PyWisp -> Runtime: Send everything
+    Kernel -> Model: Call handler for each frame
+    Kernel -> Experiment: Call handler for ID 1
+    note over Experiment: State = IDLE
+    Kernel <- Experiment: Schedule STOP EVENT
+    Kernel -> Model: EVENT STOP
+    Model -> Model: input.pwm(0)
+
+Note, that again no messages from the rig to the pc are sent within this action and no failure modes are present.

--- a/docs/communication/index.rst
+++ b/docs/communication/index.rst
@@ -1,0 +1,2 @@
+Communication Diagrams
+======================

--- a/docs/communication/index.rst
+++ b/docs/communication/index.rst
@@ -53,8 +53,8 @@ Depending on the connection type, currently the following happens:
         User <-- PyWisp: Connection not possible
     end
 
-Note that all actions occur on the machine that PyWisp is running on and no actual
-data is sent or received over any channel in this step.
+Note that all actions occur on the machine that PyWisp is running on, and no
+actual data is sent or received over any channel in this step.
 
 Powering on the rig
 -------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,9 +21,14 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
     'sphinx.ext.imgmath',
+    'sphinxcontrib.plantuml',
 ]
 
 numfig = True
+
+# define the command to build plantuml diagrams
+# plantuml = 'java -jar /path/to/plantuml.jar'
+plantuml = 'plantuml'
 
 # Add napoleon to the extension (to write/precompile google style docstrings)
 

--- a/docs/guide/index.rst
+++ b/docs/guide/index.rst
@@ -3,19 +3,20 @@ Guide
 =====
 
 This guide shows how to configure the remote part for a test rig.
-Most of the time this is some kind of PC that is connected to the rig an can be used
+Most of the time this is some kind of PC that is connected to the rig and can be used
 to start and stop experiments as well as to collect and visualize measurements.
-Regarding the code on the test rig itself, please refer to the `tool-libs` documentation.
+Regarding the code on the test rig itself, please refer to the `tool-libs
+<https://github.com/umit-iace/tool-libs>`_ documentation.
 
 To visualize and control a test rig with PyWisp some files are needed that are summarized in a project. Each project
 must include the following files:
 
-- connection.py: The implementation of all :mod:`pywisp.connection`.
+- ``connection.py``: The implementation of all :mod:`pywisp.connection`.
 - Files for the :mod:`pywisp.experimentModules`: It is recommended to have one file for each module, i.e. `controller`,
   `testbench`. For detailed information see :ref:`chapter_examples`.
-- visualization.py: The implementation of all :mod:`pywisp.visualization`.
-- defaults.sreg: The definition of all experiments.
-- main.py: Main file to register all needed :mod:`pywisp.experimentModules`, :mod:`pywisp.connection`,
+- ``visualization.py``: The implementation of all :mod:`pywisp.visualization`.
+- ``defaults.sreg``: The definition of all experiments.
+- ``main.py``: Main file to register all needed :mod:`pywisp.experimentModules`, :mod:`pywisp.connection`,
   :mod:`pywisp.visualization` and starts the GUI.
 
 Connection
@@ -43,20 +44,21 @@ testbench handling itself. To implement your functionality, derive from it and t
 
 First, declare the following member variables:
 
-- :attr:`connection` (str): The name of a class (derived from :class:`pywisp.connection.Connection`) that shall be used to
+- :attr:`connection`:``str`` -- The name of the connection class (derived from :class:`pywisp.connection.Connection`) that shall be used to
   communicate with the test rig.
-- :attr:`publicSettings` (dict): Settings for the module that will be exposed in the GUI and can be changed by the user (e.g. your
+- :attr:`publicSettings`:``dict`` -- Settings for the module that will be exposed in the GUI and can be changed by the user (e.g.
   controller gains).
-- :attr:`dataPoints` (list[str]): Labels of the measurements that come from the test rig to be used for plots.
+- :attr:`dataPoints`:``list[str]`` -- Labels of the measurements that come from the test rig to be used for plots.
 
-Then, implement the following methods that are invoked when data is send *form* PyWisp down *to* the test rig:
+Then, implement the following methods that are invoked when data is sent *from* PyWisp *to* the test rig:
 
-- :meth:`getStartParams`: Function to handle parameter, that should be set on experiment start.
-- :meth:`getStopParams`: Function to handle parameter, that should be set on experiment end.
-- :meth:`getParams`: Function to handle parameter, that should be set on start or during the experiment.
+- :meth:`getStartParams`: return parameters that should be set on experiment start.
+- :meth:`getStopParams`: return parameters that should be set on experiment end.
+- :meth:`getParams`: return parameters that should be set after start and during the experiment.
 
-All of these 3 functions must return a list of dicts each representing a data frame to be send down to the rig.
-For more information on data frames, please refer to :meth:`getParams`. To just send one bool value, an implementation
+All of these 3 functions must return a list of dicts each representing a data frame to be sent to the rig.
+They receive one positional argument, which is a list of the currently set :attr:`publicSettings` of the module.
+For more information on data frames, please refer to :ref:`communication_layer`. To just send one bool value, an implementation
 could look like
 
 .. literalinclude:: ../../examples/generic/visu/testbench.py
@@ -90,49 +92,67 @@ For detailed information see the :ref:`chapter_examples` section.
 Remote Widgets
 --------------
 
-The `Remote Widgets` give the opportunity to change the `publicSettings` of the
-:mod:`pywisp.experimentModules` without editing them in the tree view.
+The `Remote Widgets` give the opportunity to change the :attr:`publicSettings` of the
+:mod:`pywisp.experimentModules` without editing them by hand in the tree view.
 
 Currently the following types are available:
 
 * Push Button
 * Slider
-* Switch Button
+* Switch
 
-To use such widgets, either right click in the *Remote* dock container in the GUI,
-select `Add widget` and follow the wizard or manually define them under the `Remote` part
-of your experiment configuration  (an `.sreg` as explained below) like so:
+To use the widgets, either right click in the ``Remote`` dock container in the GUI,
+select ``Add widget`` and follow the wizard, or manually define them under the ``Remote`` part
+of your experiment configuration  (an ``.sreg`` as explained below) like so:
 
 .. literalinclude:: ../../examples/tcp/bur/client/default.sreg
    :language: yaml
    :lines: 23-45
 
-To export the Widgets created by the wizard right click the `Remote` dock,
-select `Copy remote source` and then paste the code into your sreg file.
+Widgets created interactively in the GUI are not automatically saved.
+To export the Widgets created by the wizard right click the ``Remote`` dock,
+select ``Copy remote source`` and paste the code into your ``.sreg`` file.
 
 Heartbeat
 ---------
 
-If an experiment shall be stopped if the connection to the rig is interrupted,
-`PyWisp` provides the possibility to send a so-called heartbeat.
-This basically is a frame with the special ID 1 at bit 1.
-To use this feature, the `Config` section of the of your `.sreg` file must be extended by the setting
+`PyWisp` provides th epossibility to automatically stop a rig if the connection
+is interrupted.
+To use this feature, the ``Config`` section of the ``.sreg`` file must include
+the setting
 
 .. code-block:: yaml
 
     Heartbeat: 100  # send a heartbeat every 100ms
 
 It can be disabled by setting the parameter to zero or omitting the entry.
-Note that the embedded code on the rig itself also has to be configured to expect such a packet,
-otherwise you will not obtain the desired behaviour.
+Note that the embedded code on the rig itself also has to be configured to expect such a packet.
+Refer to the `tool-libs <https://github.com/umit-iace/tool-libs>`_ documentation for details.
+
+Plot Configuration
+~~~~~~~~~~~~~~~~~~
+
+Additionally the plot and visualization have some configuration parameters. These are:
+
+* TimerTime: Update interval of the visualization/plot data
+* MovingWindow: Moving Window of the plot visualization
+
+They can be set interactively by right-clicking the plot in the GUI and in the Config menu.
+To save the configuration the ``defaults.sreg`` ``Config`` section can be extended with the keys:
+
+.. code-block:: yaml
+
+    TimerTime:           <time in ms>
+    MovingWindowSize:    <time in s>
+    MovingWindowEnable:  <True..enable moving window, False..disable moving window>
 
 For detailed information see the :ref:`chapter_examples` section.
 
 defaults.sreg
 -------------
 
-The `defaults.sreg` constitutes the standard configuration file for `PyWisp`. It uses a `yaml` syntax.
-Below a normal configuration with two experiments is presented:
+The ``defaults.sreg`` file constitutes the standard configuration file for `PyWisp`. It uses a ``yaml`` syntax.
+Below an example configuration with two experiments is presented:
 
 .. code-block:: yaml
 
@@ -183,21 +203,3 @@ of `Remote` configures a Push Button, that is connected to ´Value1` of the :mod
 For detailed information see the :ref:`chapter_examples` section.
 
 
-Plot Configuration
-~~~~~~~~~~~~~~~~~~
-
-Additionally the plot and visualization have some configuration parameters. These are:
-
-* TimerTime: Update interval of the visualization/plot data
-* MovingWindow: Moving Window of the plot visualization
-
-The can be set by a right click of the plot in the GUI or about the Config menu.
-To save the configuration the `defaults.sreg` can be extended by a `Config section` with the keys:
-
-.. code-block:: yaml
-
-    TimerTime:           <time in ms>
-    MovingWindowSize:    <time in s>
-    MovingWindowEnable:  <True..enable moving window, False..disable moving window>
-
-For detailed information see the :ref:`chapter_examples` section.

--- a/docs/guide/index.rst
+++ b/docs/guide/index.rst
@@ -2,35 +2,49 @@
 Guide
 =====
 
-To visulize and control a test rig with PyWisp some files are needed that are summarized in a project. Each project
+To visualize and control a test rig with PyWisp some files are needed that are summarized in a project. Each project
 must include the following files:
 
-- main.py: Main file to register all needed :mod:`pywisp.experimentModules`, :mod:`pywisp.connection`, :mod:`pywisp.visualization` and starts the GUI.
+- main.py: Main file to register all needed :mod:`pywisp.experimentModules`, :mod:`pywisp.connection`,
+  :mod:`pywisp.visualization` and starts the GUI.
 - defaults.sreg: The definition of all experiments.
-- connection.py: The implementation of all ::mod:`pywisp.connection`.
+- connection.py: The implementation of all :mod:`pywisp.connection`.
 - visualization.py: The implementation of all :mod:`pywisp.visualization`.
-- Files for the :mod:`pywisp.experimentModules`: It is recommended to have one file each module, i.e. `controller`, `testbench`. For detailed information see :ref:`chapter_examples`.
+- Files for the :mod:`pywisp.experimentModules`: It is recommended to have one file for each module, i.e. `controller`,
+  `testbench`. For detailed information see :ref:`chapter_examples`.
 
 ExperimentModule
 ----------------
 
 The experiment module class is needed to implement the different parts of the test rig, like trajectory, controller and
-testbench handling itself.
+testbench handling itself. To implement your functionality, derive from it and then implement the following:
 
-3 members must be specified:
+First, declare the following member variables:
 
-- `dataPoints`: Data points, that come from the test rig.
-- `publicSettings`: Settings, that can be changed by the user in the GUI.
-- `connection`: Connection name, that is required to read and write to the correct connection.
+- :attr:`connection` (str): The name of a class (derived from :class:`pywisp.connection.Connection`) that shall be used to
+  communicate with the test rig.
+- :attr:`publicSettings` (dict): Settings for the module that will be exposed in the GUI and can be changed by the user (e.g. your
+  controller gains).
+- :attr:`dataPoints` (list[str]): Labels of the measurements that come from the test rig to be used for plots.
 
-4 functions can be implemented:
+Then, implement the following methods that are invoked when data is send *form* PyWisp down *to* the test rig:
 
-- `getStartParams`: Function to handle parameter, that should be set on experiment start.
-- `getStopParams`: Function to handle parameter, that should be set on experiment end.
-- `getParams`: Function to handle parameter, that should be set on start or during the experiment.
-- `handleFrame`: Function to handle frames from test rig and sets the data points to show in the GUI.
+- :meth:`getStartParams`: Function to handle parameter, that should be set on experiment start.
+- :meth:`getStopParams`: Function to handle parameter, that should be set on experiment end.
+- :meth:`getParams`: Function to handle parameter, that should be set on start or during the experiment.
 
-For detailed information see the :ref:`chapter_examples` section.
+All of these 3 functions must return a list of dicts each representing a data frame to be send down to the rig.
+For more information on data frames, please refer to :meth:`getParams`. To just send one bool value, an implementation
+could look like
+
+.. literalinclude:: ../../examples/generic/visu/testbench.py
+   :language: python
+   :lines: 24-35
+
+Finally, the measurement data from the rig must be processed, to do so implement :meth:`handleFrame`
+to handle frames from test rig and sets the data points to show in the GUI.
+
+For actual implementations please refer to the :ref:`chapter_examples` section.
 
 Connection
 ----------

--- a/docs/guide/index.rst
+++ b/docs/guide/index.rst
@@ -67,10 +67,13 @@ For actual implementations please refer to the :ref:`chapter_examples` section.
 Visualizer
 ----------
 
-It is possible to have different visualizers registered. They can be selected in GUI at runtime. Currently only
-visualizers based on matplotlib are available. For the implementation the base class
-:class:`~pywisp.visualization.MplVisualizer` must be derived and the method
-:func:`~pywisp.visualization.MplVisualizer.update` should be implemented. It is recommented to use
+It is possible to have different visualizers registered.
+They can be selected in GUI at runtime.
+Currently only visualizers based on matplotlib are available.
+To visualize your rig, derive from
+:class:`~pywisp.visualization.MplVisualizer` and implement
+:func:`~pywisp.visualization.MplVisualizer.update`.
+It is recommented to use
 
 .. code-block:: python
 

--- a/docs/guide/index.rst
+++ b/docs/guide/index.rst
@@ -2,16 +2,21 @@
 Guide
 =====
 
+This guide shows how to configure the remote part for a test rig.
+Most of the time this is some kind of PC that is connected to the rig an can be used
+to start and stop experiments as well as to collect and visualize measurements.
+Regarding the code on the test rig itself, please refer to the `tool-libs` documentation.
+
 To visualize and control a test rig with PyWisp some files are needed that are summarized in a project. Each project
 must include the following files:
 
-- main.py: Main file to register all needed :mod:`pywisp.experimentModules`, :mod:`pywisp.connection`,
-  :mod:`pywisp.visualization` and starts the GUI.
-- defaults.sreg: The definition of all experiments.
 - connection.py: The implementation of all :mod:`pywisp.connection`.
-- visualization.py: The implementation of all :mod:`pywisp.visualization`.
 - Files for the :mod:`pywisp.experimentModules`: It is recommended to have one file for each module, i.e. `controller`,
   `testbench`. For detailed information see :ref:`chapter_examples`.
+- visualization.py: The implementation of all :mod:`pywisp.visualization`.
+- defaults.sreg: The definition of all experiments.
+- main.py: Main file to register all needed :mod:`pywisp.experimentModules`, :mod:`pywisp.connection`,
+  :mod:`pywisp.visualization` and starts the GUI.
 
 Connection
 ----------
@@ -168,12 +173,12 @@ Below a normal configuration with two experiments is presented:
         MplExampleVisualizer:
 
       Config:
-        TimerTime: 40
-        MovingWindowSize: 5
+        TimerTime: 40  # [] = ms, update interval of the GUI plots
+        MovingWindowSize: 5  # [] = s
         MovingWindowEnable: True
 
 In this example `Test` and `SeriesTrajectory` are derived :mod:`pywisp.experimentModules` classes. The settings below
-of `Remote` configurates a Push Button, that is connected to ´Value1` of the :mod:`pywisp.experimentModules` class
+of `Remote` configures a Push Button, that is connected to ´Value1` of the :mod:`pywisp.experimentModules` class
 `Test`. The 'Config' section shows the settings for the plot configuration.
 
 For detailed information see the :ref:`chapter_examples` section.

--- a/docs/guide/index.rst
+++ b/docs/guide/index.rst
@@ -64,10 +64,9 @@ could look like
    :lines: 24-35
 
 Finally, the measurement data from the rig must be processed, to do so implement :meth:`handleFrame`
-to handle frames from test rig and sets the data points to show in the GUI.
+to handle frames from test rig such that it can be shown in the GUI.
 
 For actual implementations please refer to the :ref:`chapter_examples` section.
-
 
 Visualizer
 ----------

--- a/docs/guide/index.rst
+++ b/docs/guide/index.rst
@@ -86,27 +86,41 @@ For detailed information see the :ref:`chapter_examples` section.
 Remote Widgets
 --------------
 
-The `Remote Widgets` give the opportunity to control direct `publicSettings` of
-:mod:`pywisp.experimentModules`. It can be added different types of widgets. Currently the following
-types are available:
+The `Remote Widgets` give the opportunity to change the `publicSettings` of the
+:mod:`pywisp.experimentModules` without editing them in the tree view.
+
+Currently the following types are available:
 
 * Push Button
 * Slider
 * Switch Button
 
-To save the configuration by means of right click the code can be exported and added to the `defaults.sreg`.
+To use such widgets, either right click in the *Remote* dock container in the GUI,
+select `Add widget` and follow the wizard or manually define them under the `Remote` part
+of your experiment configuration  (an `.sreg` as explained below) like so:
+
+.. literalinclude:: ../../examples/tcp/bur/client/default.sreg
+   :language: yaml
+   :lines: 23-45
+
+To export the Widgets created by the wizard right click the `Remote` dock,
+select `Copy remote source` and then paste the code into your sreg file.
 
 Heartbeat
 ---------
 
-`PyWisp` provides the possibility to send a heartbeat on `ID 1` at bit 1. For the configuration `Config` section of the
-`defaults.sreg` must be extended by the setting
+If an experiment shall be stopped if the connection to the rig is interrupted,
+`PyWisp` provides the possibility to send a so-called heartbeat.
+This basically is a frame with the special ID 1 at bit 1.
+To use this feature, the `Config` section of the of your `.sreg` file must be extended by the setting
 
 .. code-block:: yaml
 
-    Heartbeat: <time in ms>
+    Heartbeat: 100  # send a heartbeat every 100ms
 
-It can be diabled by set the parameter to zero.
+It can be disabled by setting the parameter to zero or omitting the entry.
+Note that the embedded code on the rig itself also has to be configured to expect such a packet,
+otherwise you will not obtain the desired behaviour.
 
 For detailed information see the :ref:`chapter_examples` section.
 
@@ -163,6 +177,7 @@ of `Remote` configurates a Push Button, that is connected to ´Value1` of the :m
 `Test`. The 'Config' section shows the settings for the plot configuration.
 
 For detailed information see the :ref:`chapter_examples` section.
+
 
 Plot Configuration
 ~~~~~~~~~~~~~~~~~~

--- a/docs/guide/index.rst
+++ b/docs/guide/index.rst
@@ -13,6 +13,23 @@ must include the following files:
 - Files for the :mod:`pywisp.experimentModules`: It is recommended to have one file for each module, i.e. `controller`,
   `testbench`. For detailed information see :ref:`chapter_examples`.
 
+Connection
+----------
+
+Before anything can happen, it is necessary to implement a communication channel to the rig.
+PyWisp already comes with generic connection types like
+:class:`pywisp.connection.SerialConnection` for communication over serial ports like USB as well
+:class:`pywisp.connection.TcpConnection` or :class:`pywisp.connection.UdpConnection` for Socket based communication.
+
+To implement your specific connection, just derive from
+:class:`pywisp.connection.Connection` or one of the classes mentioned above.
+The actual settings such as ports and baud rate can also be changed in the GUI later on.
+A simple UDP based setup could look like this:
+
+.. literalinclude:: ../../examples/generic/visu/connection.py
+   :language: python
+   :lines: 5-12
+
 ExperimentModule
 ----------------
 
@@ -46,39 +63,6 @@ to handle frames from test rig and sets the data points to show in the GUI.
 
 For actual implementations please refer to the :ref:`chapter_examples` section.
 
-Connection
-----------
-
-It is necessary to implement the used connection types, where the class name specify the name used in the GUI and the
-default settings. The settings can be changed in the GUI directly. All implementations mus derived from
-:class:`~pywisp.visualization.MplVisualizer`. Currently two connection types are available and can implemented exemplary:
-
-- Serial connection:
-
-.. code-block:: python
-
-    class ConnName(SerialConnection):
-        settings = OrderedDict([("port", '/dev/uart0'),
-                                ("baud", 115200),
-                                ])
-
-        def __init__(self):
-            SerialConnection.__init__(self,
-                                      self.settings['port'],
-                                      self.settings['baud'])
-
-
-- Tcp connection
-
-.. code-block:: python
-
-    class ConnName(TcpConnection):
-        settings = OrderedDict([("ip", '192.168.1.1'),
-                                ])
-
-        def __init__(self):
-            TcpConnection.__init__(self,
-                                   self.settings['ip'])
 
 Visualizer
 ----------

--- a/docs/guide/index.rst
+++ b/docs/guide/index.rst
@@ -75,17 +75,16 @@ Visualizer
 
 It is possible to have different visualizers registered.
 They can be selected in GUI at runtime.
-Currently only visualizers based on matplotlib are available.
+Currently, only visualizers based on matplotlib are available.
 To visualize your rig, derive from
 :class:`~pywisp.visualization.MplVisualizer` and implement
 :func:`~pywisp.visualization.MplVisualizer.update`.
-It is recommented to use
+To update the canvas, it is recommended to use
 
 .. code-block:: python
 
     self.canvas.draw_idle()
 
-to update the canvas.
 
 For detailed information see the :ref:`chapter_examples` section.
 
@@ -95,7 +94,7 @@ Remote Widgets
 The `Remote Widgets` give the opportunity to change the :attr:`publicSettings` of the
 :mod:`pywisp.experimentModules` without editing them by hand in the tree view.
 
-Currently the following types are available:
+Currently, the following types are available:
 
 * Push Button
 * Slider
@@ -103,7 +102,7 @@ Currently the following types are available:
 
 To use the widgets, either right click in the ``Remote`` dock container in the GUI,
 select ``Add widget`` and follow the wizard, or manually define them under the ``Remote`` part
-of your experiment configuration  (an ``.sreg`` as explained below) like so:
+of your experiment configuration (an ``.sreg`` as explained below) like so:
 
 .. literalinclude:: ../../examples/tcp/bur/client/default.sreg
    :language: yaml
@@ -116,7 +115,7 @@ select ``Copy remote source`` and paste the code into your ``.sreg`` file.
 Heartbeat
 ---------
 
-`PyWisp` provides th epossibility to automatically stop a rig if the connection
+`PyWisp` provides the possibility to automatically stop a rig if the connection
 is interrupted.
 To use this feature, the ``Config`` section of the ``.sreg`` file must include
 the setting
@@ -132,7 +131,7 @@ Refer to the `tool-libs <https://github.com/umit-iace/tool-libs>`_ documentation
 Plot Configuration
 ~~~~~~~~~~~~~~~~~~
 
-Additionally the plot and visualization have some configuration parameters. These are:
+Additionally, the plot and visualization have some configuration parameters. These are:
 
 * TimerTime: Update interval of the visualization/plot data
 * MovingWindow: Moving Window of the plot visualization

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ Contents:
 
   installation
   guide/index
+  communication/index
   transport/index
   examples/index
   modules/index

--- a/docs/modules/experimentModules.rst
+++ b/docs/modules/experimentModules.rst
@@ -2,5 +2,8 @@
 Experiment Modules
 ==================
 
-.. automodule:: pywisp.experimentModules
+.. autoclass:: pywisp.experimentModules.ExperimentModule
+    :members:
+
+.. autoclass:: pywisp.experimentModules.ExperimentModuleException
     :members:

--- a/docs/modules/visualization.rst
+++ b/docs/modules/visualization.rst
@@ -3,4 +3,4 @@ Visualization
 =============
 
 .. automodule:: pywisp.visualization
-    :members:
+    :members: Visualizer, MplVisualizer, VtkVisualizer

--- a/docs/transport/index.rst
+++ b/docs/transport/index.rst
@@ -84,7 +84,7 @@ When a frame is received by pywisp, it has to be unpacked to further process the
 
 .. literalinclude:: ../../examples/generic/visu/trajectory.py
    :language: python
-   :lines: 42-44
+   :lines: 38-45
 
 Note that currently no logic is available in pywisp to unpack a series of frames
 and join them into one set of measurements.

--- a/docs/transport/index.rst
+++ b/docs/transport/index.rst
@@ -28,6 +28,29 @@ On `Arduino UNO` the limit is at 50 bytes due to the internal memory.
 When manually packing the frames, this limit should be respected otherwise
 packet loss may occur.
 
+Frame IDs
+---------
+
+.. list-table::
+    :widths: 50 50
+    :header-rows: 1
+
+    * - ID
+      - Meaning
+    * - 0
+      - Unknown
+    * - 1
+      - Experiment Control:
+
+        * If byte 1 is set: Heartbeat packet from PyWisp
+        * Else: read byte 0 as desired alive state
+
+    * - 2 - 9
+      - Unknown / Reserved?
+    * - 10 - 255
+      - User defined
+
+
 Packing a frame
 ---------------
 

--- a/docs/transport/index.rst
+++ b/docs/transport/index.rst
@@ -59,7 +59,7 @@ It is up to the user to guarantee that:
 Packing a frame
 ---------------
 
-To send data to the test rig, it has to ba packed into MIN-Frames before it can be handed over
+To send data to the test rig, it has to be packed into MIN-Frames before it can be handed over
 to the connection.
 Using the :mod:`struct` module from the standard library, the payload can be created as follows
 

--- a/docs/transport/index.rst
+++ b/docs/transport/index.rst
@@ -1,18 +1,18 @@
-Transport Layer
+.. _communication_layer:
+
+Communication Layer
 ===============
 
-To handle all communication interfaces for B&R, Raspberry Pi, Arduino, ... on the same way a middle layer is implemented
-called `Transport-Layer`. Additionally to this for the data handling the frame based protocol
-`MIN-Protocol <https://github.com/min-protocol/min>`_ is used.
+To handle all communication interfaces for the different underlying hardwares in a similar way,
+a communication protocol is introduced.
+This is based on the `MIN-Protocol <https://github.com/min-protocol/min>`_.
 
-Currently only for wired serial connected devices, like Arduino or STMs, the `MIN-Protocol` itself is used.
-On devices where a `TCP`-based approach or a wifi serial connection is used, only the frame handling by `MIN` is
-applied.
+Currently the ``MIN``-specified frame packing is not used on `TCP`-based interfaces.
 
 MIN-Frame
 ---------
 
-The smallest unit in the communication stack, each `MIN-Frame` data has the structure:
+The smallest unit in the communication stack, each ``Frame`` has the structure:
 
 .. list-table::
     :widths: 50 50
@@ -20,8 +20,8 @@ The smallest unit in the communication stack, each `MIN-Frame` data has the stru
 
     * - ID
       - Payload
-    * - unique identifier, packed as one byte
-      - data, packed as byte array
+    * - unique identifier, packed as a 7-bit value (``0x0`` - ``0x7f``)
+      - data, packed as little-endian byte array
 
 Note that the maximum possible length of a frame differs on each device.
 On `Arduino UNO` the limit is at 50 bytes due to the internal memory.
@@ -37,18 +37,23 @@ Frame IDs
 
     * - ID
       - Meaning
-    * - 0
-      - Unknown
     * - 1
       - Experiment Control:
 
-        * If byte 1 is set: Heartbeat packet from PyWisp
-        * Else: read byte 0 as desired alive state
+        Payload (1 byte) is interpreted as
 
-    * - 2 - 9
-      - Unknown / Reserved?
-    * - 10 - 255
+        - ``0`` -- STOP experiment
+        - ``1`` -- START experiment
+        - ``2`` -- HEARTBEAT
+
+    * - 0, 2 - 127
       - User defined
+
+It is up to the user to guarantee that:
+
+    * No system reserved IDs are used
+    * IDs are uniquely assigned
+    * Every ID used to send data has a corresponding handler
 
 
 Packing a frame
@@ -69,22 +74,15 @@ a trajectory), the helper function :meth:`pywisp.utils.packArrayToFrame` may be 
    :language: python
    :lines: 31-34
 
-In the end it is up to the user to guarantee that:
-
-    * No system reserved IDs are used
-    * None of several ExperimentModules do use the same frame ID
-    * Every frame ID used on the rig or the remote has an appropriate
-      handler on the other side
-
 
 Unpacking a frame
 -----------------
 
-When a frame is received by pywisp, it has to be unpacked to further process the information therein.
+When a frame is received by PyWisp, it has to be unpacked to further process the information therein.
 
 .. literalinclude:: ../../examples/generic/visu/trajectory.py
    :language: python
    :lines: 38-45
 
-Note that currently no logic is available in pywisp to unpack a series of frames
+Note that currently no logic is available in PyWisp to unpack a series of frames
 and join them into one set of measurements.

--- a/docs/transport/index.rst
+++ b/docs/transport/index.rst
@@ -69,6 +69,13 @@ a trajectory), the helper function :meth:`pywisp.utils.packArrayToFrame` may be 
    :language: python
    :lines: 31-34
 
+In the end it is up to the user to guarantee that:
+
+    * No system reserved IDs are used
+    * None of several ExperimentModules do use the same frame ID
+    * Every frame ID used on the rig or the remote has an appropriate
+      handler on the other side
+
 
 Unpacking a frame
 -----------------

--- a/docs/transport/index.rst
+++ b/docs/transport/index.rst
@@ -9,18 +9,10 @@ Currently only for wired serial connected devices, like Arduino or STMs, the `MI
 On devices where a `TCP`-based approach or a wifi serial connection is used, only the frame handling by `MIN` is
 applied.
 
-Transport Class
----------------
-
-The primary task of the class is to handle the in and output data. The input data is converted from byte array frame
-structure to matching data type and sets the program variables. The output data is capsuled in frames by converting the
-data in byte arrays and sends out. Additionally to this, on serial used devices, it handles the communication (read and
-write operations of serial).
-
 MIN-Frame
 ---------
 
-Each `MIN-Frame` data has the structure:
+The smallest unit in the communication stack, each `MIN-Frame` data has the structure:
 
 .. list-table::
     :widths: 50 50
@@ -31,4 +23,38 @@ Each `MIN-Frame` data has the structure:
     * - unique identifier, packed as one byte
       - data, packed as byte array
 
-The byte array length differs at each device. On `Arduino UNO` the limit is at 50 bytes, because of the intern memory.
+Note that the maximum possible length of a frame differs on each device.
+On `Arduino UNO` the limit is at 50 bytes due to the internal memory.
+When manually packing the frames, this limit should be respected otherwise
+packet loss may occur.
+
+Packing a frame
+---------------
+
+To send data to the test rig, it has to ba packed into MIN-Frames before it can be handed over
+to the connection.
+Using the :mod:`struct` module from the standard library, the payload can be created as follows
+
+.. literalinclude:: ../../examples/generic/visu/trajectory.py
+   :language: python
+   :lines: 27-29
+
+However, if more than just a handful of parameters are to be sent (for example when sending the interpolation points of
+a trajectory), the helper function :meth:`pywisp.utils.packArrayToFrame` may be used:
+
+.. literalinclude:: ../../examples/generic/visu/trajectory.py
+   :language: python
+   :lines: 31-34
+
+
+Unpacking a frame
+-----------------
+
+When a frame is received by pywisp, it has to be unpacked to further process the information therein.
+
+.. literalinclude:: ../../examples/generic/visu/trajectory.py
+   :language: python
+   :lines: 42-44
+
+Note that currently no logic is available in pywisp to unpack a series of frames
+and join them into one set of measurements.

--- a/examples/generic/visu/connection.py
+++ b/examples/generic/visu/connection.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-from pywisp import connection
+from pywisp.connection import UdpConnection
 
 
-class Connection(connection.UdpConnection):
+class Connection(UdpConnection):
     settings = {
         "ip": '127.0.0.1',
         "port": 45670,

--- a/examples/generic/visu/default.sreg
+++ b/examples/generic/visu/default.sreg
@@ -13,6 +13,6 @@
     MplDoublePendulumVisualizer:
 
   Config:
-    MovingWindowSize: 10
-    MovingWindowEnable: True
-    HeartbeatTime: 0
+    MovingWindowEnable: True  # Enable windowing
+    MovingWindowSize: 10 # Show past 10 seconds of measurements
+    HeartbeatTime: 0  # disable keep-alive packets

--- a/examples/generic/visu/testbench.py
+++ b/examples/generic/visu/testbench.py
@@ -21,7 +21,7 @@ class DoublePendulum(ExperimentModule):
 
     connection = Connection.__name__
 
-    def getParams(self, data):
+    def getParams(self, data) -> list[dict]:
         payloadConfig = struct.pack('<B',
                                     int(data[0]),
                                     )
@@ -34,7 +34,7 @@ class DoublePendulum(ExperimentModule):
 
         return dataPoints
 
-    def handleFrame(self, frame):
+    def handleFrame(self, frame) -> dict:
         dataPoints = {}
         fid = frame.min_id
         if fid == 15:

--- a/examples/generic/visu/trajectory.py
+++ b/examples/generic/visu/trajectory.py
@@ -36,13 +36,9 @@ class Trajectory(ExperimentModule):
         return dataPoints
 
     def handleFrame(self, frame):
-        dataPoints = {}
-        fid = frame.min_id
-        if fid == 25:
-            data = struct.unpack(f'<L{len(Trajectory.dataPoints)}d', frame.payload)
-            dataPoints['Time'] = data[0]
-            dataPoints['DataPoints'] = dict(zip(Trajectory.dataPoints, data[1:]))
-        else:
-            dataPoints = None
-
-        return dataPoints
+        if frame.id != 25: return None
+        data = struct.unpack(f'<L{len(self.dataPoints)}d', frame.payload)
+        return {
+            'Time': data[0],
+            'DataPoints': dict(zip(self.dataPoints, data[1:]))
+        }

--- a/examples/generic/visu/visualization.py
+++ b/examples/generic/visu/visualization.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-
 import matplotlib as mpl
 import matplotlib.patches
 import matplotlib.transforms
 import numpy as np
-from exampleData import settings as st
 
 from pywisp.visualization import MplVisualizer
+
+from exampleData import settings as st
 
 
 class MplDoublePendulumVisualizer(MplVisualizer):
@@ -16,15 +16,15 @@ class MplDoublePendulumVisualizer(MplVisualizer):
         self.axes.set_ylim(st.yMinPlot, st.yMaxPlot)
         self.axes.set_aspect("equal")
 
-        self.beam = mpl.patches.Rectangle(xy=[-st.beamLength / 2,
+        self.beam = mpl.patches.Rectangle(xy=(-st.beamLength / 2,
                                               -(st.beamHeight
-                                                + st.cartHeight / 2)],
+                                                + st.cartHeight / 2)),
                                           width=st.beamLength,
                                           height=st.beamHeight,
                                           color="lightgrey")
 
-        self.cart = mpl.patches.Rectangle(xy=[-st.cartLength / 2,
-                                              -st.cartHeight / 2],
+        self.cart = mpl.patches.Rectangle(xy=(-st.cartLength / 2,
+                                              -st.cartHeight / 2),
                                           width=st.cartLength,
                                           height=st.cartHeight,
                                           color="dimgrey")
@@ -36,7 +36,7 @@ class MplDoublePendulumVisualizer(MplVisualizer):
             zorder=3)
 
         self.pendulum1 = mpl.patches.Rectangle(
-            xy=[-st.pendulum1Radius, 0],
+            xy=(-st.pendulum1Radius, 0),
             width=2 * st.pendulum1Radius,
             height=st.pendulum1Height,
             color="#E87B14",  # TUD CD HKS 07_K
@@ -47,7 +47,7 @@ class MplDoublePendulumVisualizer(MplVisualizer):
             color="#000000",  # TUD CD HKS 07_K
             zorder=3)
         self.pendulum2 = mpl.patches.Rectangle(
-            xy=[-st.pendulum2Radius, st.pendulum1Height],
+            xy=(-st.pendulum2Radius, st.pendulum1Height),
             width=2 * st.pendulum2Radius,
             height=st.pendulum2Height,
             color="#0059A3",  # TUD CD HKS 44_K

--- a/examples/tcp/bur/client/default.sreg
+++ b/examples/tcp/bur/client/default.sreg
@@ -21,26 +21,26 @@
     Value4: 1
 
   Remote:
-    PushExample:
-      Module: Test
-      Parameter: Value1
-      valueOn: '99.99'
+    PushExample:  # A push button
+      Module: Test  # Name of the ExperimentModule to target
+      Parameter: Value1  # Name of the setting to change
       widgetType: PushButton
+      valueOn: '99.99'
       shortcut: P
-    SwitchExample:
-      Module: Test
-      Parameter: Value2
+    SwitchExample: # A switch
+      Module: Test  # Name of the ExperimentModule to target
+      Parameter: Value2  # Name of the setting to change
+      widgetType: Switch
       valueOff: '11.1'
       valueOn: '22.2'
-      widgetType: Switch
       shortcut: O
-    SliderExample:
-      Module: Test
-      Parameter: Value3
+    SliderExample:  # A slider
+      Module: Test  # Name of the ExperimentModule to target
+      Parameter: Value3  # Name of the setting to change
+      widgetType: Slider
       maxSlider: 255
       minSlider: 0
       stepSlider: 1
-      widgetType: Slider
       shortcutPlus: H
       shortcutMinus: G
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
     'PyYAML',
     'python-dateutil',
     'pandas',
-    "sphinx",
     'build',
 ]
 
@@ -38,3 +37,9 @@ version = {attr = "pywisp.__version__"}
 
 [tool.uv.workspace]
 members = ["examples/generic/doublePendulum"]
+
+[dependency-groups]
+dev = [
+    "sphinx",
+    "sphinxcontrib-plantuml>=0.31",
+]

--- a/pywisp/connection.py
+++ b/pywisp/connection.py
@@ -148,7 +148,7 @@ class SerialConnection(Connection):
             1000000, 1152000, 1500000, 2000000, 2500000, 3000000, 3500000,4000000,
             )
 
-    def __init__(self, port, baud):
+    def __init__(self, port: str, baud: int):
         self.serial = serial.Serial(timeout=0.01)
         if baud not in self.supported_baudrates:
             raise ValueError(f"Baudrate {baud} not supported. " 

--- a/pywisp/experimentModules.py
+++ b/pywisp/experimentModules.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 
 from PyQt5.QtCore import QObject
 
-from min import Frame
+from .min import Frame
 
 pyqtWrapperType = type(QObject)
 

--- a/pywisp/experimentModules.py
+++ b/pywisp/experimentModules.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 import logging
 from abc import ABCMeta, abstractmethod
+from collections import OrderedDict
 
 from PyQt5.QtCore import QObject
+
+from min import Frame
 
 pyqtWrapperType = type(QObject)
 
@@ -14,22 +17,20 @@ class ExperimentModuleMeta(ABCMeta, pyqtWrapperType):
 
 
 class ExperimentModuleException(Exception):
+    """
+    Special exception used internally be pywisp to deal with errors arising from
+    packing and parsing data for and from the rig.
+    """
     pass
 
 
 class ExperimentModule(QObject, metaclass=ExperimentModuleMeta):
     """
-    Smallest unit of the framework.
+    Base unit to build an experiment.
+
     This class provides necessary functions like start, stop and general
     parameter handling and holds all settings that can be accessed by the
     user.
-    The :py:attr:`publicSettings` are rendered by the GUI. All entries
-    stated in this dictionary will be available as changeable settings for the
-    module. On initialization, a possibly modified (in terms of its values) version of
-    this dict will be passed back to this class and is thenceforward available
-    via the :py:attr:`settings` property.
-    The :py:attr:`dataPoints` are accessible by the GUI for plotting.
-    The :py:attr:`connection` determines the connection interface.
     """
     def __init__(self):
         QObject.__init__(self, None)
@@ -37,32 +38,80 @@ class ExperimentModule(QObject, metaclass=ExperimentModuleMeta):
 
     @property
     @abstractmethod
-    def publicSettings(self):
+    def publicSettings(self) -> OrderedDict:
+        """
+        Public settings of the module that are shown in the GUI.
+        All entries
+        stated in this dictionary will be available as changeable settings for the
+        module. On initialization, a possibly modified (in terms of its values) version of
+        this dict will be passed back to this class and is thenceforward available
+        via the :py:attr:`settings` property.
+        """
         pass
 
     @property
     @abstractmethod
-    def dataPoints(self):
+    def dataPoints(self) -> list[str]:
+        """
+        List of labels for all data points that can be received from this module.
+        These are used to label the measurements in the GUI for plotting.
+        """
         pass
 
     @property
     @abstractmethod
-    def connection(self):
+    def connection(self) -> str:
+        """
+        Name of the connection class to be used.
+        """
         pass
 
     @abstractmethod
-    def handleFrame(self, frame):
+    def handleFrame(self, frame: Frame) -> dict:
+        """
+        Handle frames from test rig so they can be shown in the GUI.
+
+        This function must return a dictionary with the following keys:
+
+        * Time (float): Timestamp of the measurement.
+        * DataPoints (dict): Dictionary of measurements where the keys are the labels and the values hold the
+          actual data.
+
+        Note:
+            To unpack the frame use the :mod:`struct` module.
+        """
         pass
 
     @abstractmethod
-    def getStartParams(self, *args):
+    def getStartParams(self, *args) -> list[dict]:
+        """
+        Data to be sent to the test rig when starting an experiment
+        See :meth:`getParams` for details.
+        """
         pass
 
     @abstractmethod
-    def getStopParams(self, *args):
+    def getStopParams(self, *args) -> list[dict]:
+        """
+        Data to be sent to the test rig when stopping an experiment
+        See :meth:`getParams` for details.
+        """
         pass
 
     @abstractmethod
-    def getParams(self, *args):
+    def getParams(self, *args) -> list[dict]:
+        """
+        Data to be sent to the test everytime a setting is changed in the GUI
+
+        This function must return a list of data frames to be sent, where each frame is given
+        by a dictionary with the following keys:
+
+            * id (int): Frame ID to help the test rig sort out what the frame contains.
+              This must be unique for the whole application, or you will be in trouble.
+            * msg (bytes): The actual payload.
+
+        Note:
+            To construct the payload use the :mod:`struct` module.
+        """
         pass
 

--- a/pywisp/utils.py
+++ b/pywisp/utils.py
@@ -83,15 +83,19 @@ def getResource(resName, resType="icons"):
     return os.path.join(resource_path, resName)
 
 
-def getFormatedStructString(dataLenFloat, dataLenInt, lenFloat):
+def getFormatedStructString(dataLenFloat: int, dataLenInt: int , lenFloat: int) -> str:
     """
     Returns a format string for the struct package by given float and integer length and
     count of floats.
 
     :param dataLenFloat: length of float datatype
+    :type dataLenFloat: int
     :param dataLenInt: length of integer datatype
+    :type dataLenInt: int
     :param lenFloat: length of float data
-    :return:
+    :type lenFloat: int
+
+    :return: Struct-type format string that encodes the reuqired data fields.
     """
     if dataLenFloat == 4:
         floatStr = 'f'
@@ -114,16 +118,22 @@ def getFormatedStructString(dataLenFloat, dataLenInt, lenFloat):
     return fmtStr
 
 
-def packArrayToFrame(id, data, frameLen, dataLenFloat, dataLenInt):
+def packArrayToFrame(id: int, data: list[float], frameLen: int, dataLenFloat: int, dataLenInt: int) -> list[dict]:
     """
-    Packs data to an array of dataPoints with given identifier.
+    Packs a data array into a list of payloads that do not exceed a given frame length
 
-    :param id: identifier of frame
-    :param data: data of frame
-    :param frameLen: maximal data size of frame
-    :param dataLenFloat: length of float datatype
-    :param dataLenInt: length of integer datatype
-    :return: array of dataPoints (id + payload)
+    :param id: Frame ID to use
+    :type id: int
+    :param data: Data to pack
+    :type data: List of floats
+    :param frameLen: Maximum size of frame for the given architecture
+    :type frameLen: int
+    :param dataLenFloat: Size of a float on the given architecture in bytes
+    :type dataLenFloat: int
+    :param dataLenInt: Size of an int on the given architecture in bytes
+    :type dataLenInt: int
+
+    :return: List of MIN-Frames, encoded in dictionaries with keys `id` and `msg`.
     """
     completeData = len(data) * dataLenFloat + 1 * dataLenInt
     N = np.ceil(completeData / frameLen)

--- a/pywisp/visualization.py
+++ b/pywisp/visualization.py
@@ -37,9 +37,8 @@ except ImportError as e:
 
 class Visualizer(metaclass=ABCMeta):
     """
-    Base Class for animation
+    Base class for all visualizations
     """
-
     def __init__(self):
         self.frameCounter = 0
         self.fileNameCounter = 0
@@ -62,14 +61,16 @@ class Visualizer(metaclass=ABCMeta):
         self.picturePath = createDir('ani_' + self.expName)
 
     @abstractmethod
-    def saveIfChecked(self):
+    def saveIfChecked(self) -> bool:
         pass
 
     @abstractmethod
-    def update(self, dataPoints):
+    def update(self, dataPoints: dict):
         """
-        Abstract method to update the canvas with new measurement values.
-        :param dataPoints: All the measured data points
+        Update the canvas with new measurement values.
+
+        :param dataPoints: All measurements from the current time step
+        :type dataPoints: dict
         """
         pass
 
@@ -154,13 +155,9 @@ class MplVisualizer(Visualizer):
     def saveIfChecked(self):
         """
         Must be called after self.draw_idle() in implementation.
-        :return:
         """
         if self.saveAnimation:
             fileName = self.picturePath + os.path.sep + self.timeStamp + "%04d" % self.fileNameCounter + '.png'
             self.fig.savefig(fileName, format='png', dpi=self.dpi)
             self.fileNameCounter += 1
             self.frameCounter += 1
-
-    def update(self, dataPoints):
-        pass


### PR DESCRIPTION
Before drafting an RFC I wanted to clarify some points about the current state of affairs.

I added some insights I gained in the last year and fixed some typos in the docs.

To disentangle the communication situation I added plantUML based diagrams that need plantuml to be installed on the machine where the docs are build. If that is a problem I can try to find other ways to generate them.

To easy building the docs I also introduced a dev dependency group as sphinx is not needed otherwise.

@jhalmen please have a look at the "rig" part of those diagrams as I am still not completely sure how the kernel and the experiment interact in detail (although the experiment's state machine is already quite stripped down).

After this PR is done, I will create a new one that will hold the diagrams for the new design proposal. I guess I will create a discussion for that one, then.